### PR TITLE
Use REST API in genie-space-diagnostics for cross-compute compatibility

### DIFF
--- a/genie-space-diagnostics/SKILL.md
+++ b/genie-space-diagnostics/SKILL.md
@@ -43,6 +43,10 @@ Read `scripts/fetch_space.py` for the implementation, then execute it:
   space_config
   ```
 
+**Databricks notebook notes:**
+- The script uses the REST API (`client.api_client.do()`) rather than the SDK's `genie.get_space()` — this works reliably across all SDK versions and compute types, including serverless.
+- On serverless compute, `client.config.token` is not directly accessible — `api_client.do()` handles authentication automatically, so avoid raw `requests.get()` calls.
+
 This outputs JSON with keys: `title`, `description`, `space_id`, `warehouse_id`, `workspace_host`, `serialized_space` (parsed dict).
 
 ### Step 2b: Save Raw Config

--- a/genie-space-diagnostics/scripts/fetch_space.py
+++ b/genie-space-diagnostics/scripts/fetch_space.py
@@ -2,6 +2,10 @@
 """
 Fetch a Databricks Genie Space's serialized configuration.
 
+Uses the REST API directly (GET /api/2.0/genie/spaces/{space_id}) to ensure
+compatibility across all compute types (serverless, classic, interactive)
+and SDK versions.
+
 Usage: python fetch_space.py <space_id>
 Output: JSON to stdout
 Exit codes: 0 success, 1 error (message to stderr)
@@ -37,11 +41,12 @@ def fetch_space(space_id: str) -> dict:
         )
         sys.exit(1)
 
+    # Use REST API directly — works across all compute types and SDK versions.
+    # The SDK's genie.get_space() may not support include_serialized_space on
+    # older SDK versions bundled with some Databricks notebook runtimes.
+    path = f"/api/2.0/genie/spaces/{space_id}?include_serialized_space=true"
     try:
-        space = client.genie.get_space(
-            space_id=space_id,
-            include_serialized_space=True,
-        )
+        response = client.api_client.do("GET", path)
     except Exception as e:
         error_msg = str(e)
         if "PERMISSION_DENIED" in error_msg or "403" in error_msg:
@@ -58,7 +63,8 @@ def fetch_space(space_id: str) -> dict:
             print(f"Error: Failed to fetch space '{space_id}': {e}", file=sys.stderr)
         sys.exit(1)
 
-    if not space.serialized_space:
+    serialized_space = response.get("serialized_space")
+    if not serialized_space:
         print(
             "Error: Could not retrieve serialized_space. "
             "Ensure you have CAN EDIT permission on the Genie Space.",
@@ -67,12 +73,12 @@ def fetch_space(space_id: str) -> dict:
         sys.exit(1)
 
     return {
-        "title": space.title,
-        "description": space.description,
+        "title": response.get("title"),
+        "description": response.get("description"),
         "space_id": space_id,
-        "warehouse_id": space.warehouse_id,
+        "warehouse_id": response.get("warehouse_id"),
         "workspace_host": client.config.host,
-        "serialized_space": json.loads(space.serialized_space),
+        "serialized_space": json.loads(serialized_space),
     }
 
 


### PR DESCRIPTION
## Summary
- Replaced SDK `genie.get_space()` with `client.api_client.do()` in `fetch_space.py` for reliable cross-compute-type and cross-SDK-version compatibility (serverless, classic, interactive)
- Added Databricks notebook notes to `SKILL.md` about REST API usage and serverless token handling
- Aligns with existing patterns in `genie-space-optimizer` scripts (`run_eval.py`, `update_space.py`)

## Test plan
- [x] Run `python genie-space-diagnostics/scripts/fetch_space.py <space_id>` locally and verify JSON output structure
- [x] Paste `fetch_space()` into a Databricks notebook cell and run against a known space on serverless compute
- [x] Confirm output has keys: `title`, `description`, `space_id`, `warehouse_id`, `workspace_host`, `serialized_space` (parsed dict)

This pull request was AI-assisted by Isaac.