### PR TITLE
Add SPEC.md template for create-genie-space

### DIFF
--- a/genie-code/create-genie-space/SKILL.md
+++ b/genie-code/create-genie-space/SKILL.md
@@ -7,6 +7,10 @@ description: "Create or refine an initial Databricks Genie Space design from Uni
 
 Create a focused Genie Space using Databricks-native context. Rely on Genie Code Agent mode to inspect Unity Catalog metadata, open workspace assets, run approved notebook or SQL editor steps, and read returned output.
 
+## Spec-Driven Intake
+
+When the user provides or references a completed `SPEC.md`, read that file before gathering requirements. When the user asks for a spec-driven workflow without a completed spec, use this skill folder's `SPEC.md` template as the intake checklist. Treat user-filled fields as requirements or hypotheses, fill Genie Code sections only with read-only workspace evidence, and keep unresolved `TBD` items visible as assumptions, limitations, or questions. Do not treat unconfirmed metric definitions, joins, fiscal rules, default filters, or benchmark answers in the spec as validated until workspace evidence or user confirmation supports them.
+
 ## Hard Rules
 
 - Use only bounded read-only SQL to inspect data: `SELECT`, `WITH`, `SHOW`, `DESCRIBE`, `EXPLAIN`, and `information_schema`.

--- a/genie-code/create-genie-space/SPEC.md
+++ b/genie-code/create-genie-space/SPEC.md
@@ -1,0 +1,298 @@
+# Genie Space SPEC.md Template
+
+Use this template before invoking the `create-genie-space` skill when you want a spec-driven Genie Space creation flow.
+
+Unknowns may be marked `TBD`. Use fully qualified Unity Catalog identifiers (`catalog.schema.object`) whenever known. Do not paste secrets, tokens, credentials, sensitive free text, or unnecessary raw sample data.
+
+This spec is a design input, not approval to create or update a live Genie Space. Genie Code should complete the profiling and readiness sections only with read-only workspace evidence.
+
+## Space Brief
+
+| Field | Value |
+| --- | --- |
+| Draft Space title | TBD |
+| Owner/requester | TBD |
+| Intended audience | TBD |
+| Primary purpose | TBD |
+| Success criteria | TBD |
+| Expected usage mode | Exploratory Q&A / executive reporting / operational triage / benchmarked validation / mixed |
+| In-scope questions | TBD |
+| Out-of-scope questions | TBD |
+| Security or access caveats | TBD |
+
+## Priority Business Questions
+
+Capture 3-5 realistic questions the audience will ask. Genie Code fills readiness confidence after profiling.
+
+### Question 1
+
+- Business question:
+- Expected answer shape: single number / table / trend / ranking / comparison / narrative synthesis / other
+- Required measures:
+- Required dimensions or groupings:
+- Required filters:
+- Date, fiscal, or timezone logic:
+- Candidate source hints:
+- Benchmark needed: none / SQL answer / Agent evaluation notes / both
+- Readiness confidence (Genie Code fills): High / Medium / Low
+- Readiness notes (Genie Code fills):
+
+### Question 2
+
+- Business question:
+- Expected answer shape:
+- Required measures:
+- Required dimensions or groupings:
+- Required filters:
+- Date, fiscal, or timezone logic:
+- Candidate source hints:
+- Benchmark needed: none / SQL answer / Agent evaluation notes / both
+- Readiness confidence (Genie Code fills): High / Medium / Low
+- Readiness notes (Genie Code fills):
+
+### Question 3
+
+- Business question:
+- Expected answer shape:
+- Required measures:
+- Required dimensions or groupings:
+- Required filters:
+- Date, fiscal, or timezone logic:
+- Candidate source hints:
+- Benchmark needed: none / SQL answer / Agent evaluation notes / both
+- Readiness confidence (Genie Code fills): High / Medium / Low
+- Readiness notes (Genie Code fills):
+
+### Optional Question 4
+
+- Business question:
+- Expected answer shape:
+- Required measures:
+- Required dimensions or groupings:
+- Required filters:
+- Date, fiscal, or timezone logic:
+- Candidate source hints:
+- Benchmark needed: none / SQL answer / Agent evaluation notes / both
+- Readiness confidence (Genie Code fills): High / Medium / Low
+- Readiness notes (Genie Code fills):
+
+### Optional Question 5
+
+- Business question:
+- Expected answer shape:
+- Required measures:
+- Required dimensions or groupings:
+- Required filters:
+- Date, fiscal, or timezone logic:
+- Candidate source hints:
+- Benchmark needed: none / SQL answer / Agent evaluation notes / both
+- Readiness confidence (Genie Code fills): High / Medium / Low
+- Readiness notes (Genie Code fills):
+
+## Candidate Data Sources
+
+Start with a focused set, ideally 5 or fewer objects. Include tables, standard views, and existing Metric Views only.
+
+| Identifier | Type | Business role | Inclusion reason | Known grain | Freshness or SLA | Owner | Caveats |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| `catalog.schema.object` | table / view / Metric View | TBD | TBD | TBD | TBD | TBD | TBD |
+
+### Metric View Details
+
+Complete this section for each candidate Metric View.
+
+#### `catalog.schema.metric_view`
+
+- Governed measures:
+- Governed dimensions:
+- Built-in filters:
+- Time dimensions:
+- Display names and synonyms:
+- Formatting metadata:
+- Known query pattern using `MEASURE()`:
+- Upstream semantic gaps:
+- Should underlying source tables also be attached? no / yes, because:
+
+### Table And Standard View Details
+
+Complete this section for each candidate table or standard view.
+
+#### `catalog.schema.table_or_view`
+
+- Business description:
+- Grain:
+- Primary time columns:
+- Candidate key columns:
+- Candidate measures:
+- Useful dimensions and filters:
+- Likely joins:
+- Join evidence or confirmation needed:
+- Columns to hide from Genie:
+- Sensitive, noisy, or low-value fields:
+- Data quality caveats already known:
+
+## Business Semantics
+
+### KPI And Metric Definitions
+
+| Name | Definition or formula | Numerator | Denominator | Exclusions | Governed by Metric View? | Confirmation status |
+| --- | --- | --- | --- | --- | --- | --- |
+| TBD | TBD | TBD | TBD | TBD | yes / no | confirmed / needs confirmation / TBD |
+
+### Calendar, Time, And Defaults
+
+- Fiscal calendar:
+- Timezone:
+- Default date range:
+- Default filters:
+- Default currency or units:
+- Rounding or formatting conventions:
+
+### Terminology
+
+| User term | Meaning | Maps to source, column, measure, or value | Preferred interpretation | Confirmation status |
+| --- | --- | --- | --- | --- |
+| TBD | TBD | TBD | TBD | confirmed / needs confirmation / TBD |
+
+### Ambiguities To Resolve
+
+- Ambiguous metric definitions:
+- Ambiguous joins:
+- Ambiguous filters or segment definitions:
+- Terms that may mean different things to different users:
+
+## Genie Space Design Decisions
+
+Genie Code should prefer structured configuration surfaces over broad text instructions.
+
+### Data Sources To Attach
+
+| Identifier | Attach? | Reason | Questions supported | Limitations |
+| --- | --- | --- | --- | --- |
+| `catalog.schema.object` | yes / no / TBD | TBD | TBD | TBD |
+
+### Metadata And Synonyms
+
+- Space or source descriptions to add:
+- Column descriptions to add:
+- Metric View data-source descriptions to add in the Genie Space:
+- Column or measure synonyms:
+- Display-name conventions:
+
+### Prompt Matching And Entity Matching
+
+List categorical string fields users are likely to mention directly. Genie Code should verify eligibility, cardinality, and useful values before enabling.
+
+| Source | Column | User-facing values or terms | Enable format assistance? | Enable entity matching? | Evidence |
+| --- | --- | --- | --- | --- | --- |
+| TBD | TBD | TBD | yes / no / TBD | yes / no / TBD | Genie Code fills |
+
+### Hidden Fields
+
+List ingestion metadata, audit fields, hashes, raw JSON, embeddings, secrets, sensitive free text, unused PII, and other fields that should be hidden from end-user context.
+
+| Source | Column | Reason to hide | Confirmed? |
+| --- | --- | --- | --- |
+| TBD | TBD | TBD | yes / no / TBD |
+
+### Joins
+
+Only include joins supported by constraints, profiling, query history, naming evidence, or user confirmation.
+
+| Left source and key | Right source and key | Relationship | Business meaning | Evidence required or observed |
+| --- | --- | --- | --- | --- |
+| TBD | TBD | many-to-one / one-to-many / one-to-one / many-to-many / TBD | TBD | TBD |
+
+### SQL Snippets, Examples, Functions, And Text Instructions
+
+- Reusable filter snippets:
+- Reusable expression snippets:
+- Reusable measure snippets:
+- Example SQL patterns needed for complex questions:
+- SQL functions to expose, if any:
+- Text instructions needed for global behavior only:
+
+If text instructions are proposed, include:
+
+```markdown
+## Text Instruction Justification
+
+- Exact instruction text:
+- Why structured surfaces were insufficient:
+- Intended global behavior:
+- Possible overreach or regression risk:
+- How the instruction will be reviewed or validated:
+```
+
+## Sample Questions And Benchmarks
+
+### Sample Questions
+
+Sample questions should be user-facing starting points, not copied benchmark tests.
+
+1. TBD
+2. TBD
+3. TBD
+4. TBD
+5. TBD
+
+### Benchmark Candidates
+
+Benchmark literals, parameter defaults, and expected SQL should use profiled values. Do not invent statuses, regions, categories, dates, or IDs. Do not copy benchmark answer SQL into example SQL.
+
+| Question | Target mode | Expected answer strategy | Sources and logic covered | Validation status |
+| --- | --- | --- | --- | --- |
+| TBD | SQL answer / Agent evaluation notes / both | TBD | TBD | not validated / EXPLAIN checked / read-only executed |
+
+## Profiling And Readiness Evidence
+
+Genie Code fills this section during read-only inspection.
+
+### Read-Only Validation Performed
+
+- Metadata inspected:
+- SQL commands used:
+- Queries executed or explained:
+- System lineage/query history checked:
+- Limitations:
+
+### Source Profiling Summary
+
+| Source | Row count | Grain | Freshness/date range | Key quality notes | Useful categorical values | Sensitive/noisy fields |
+| --- | --- | --- | --- | --- | --- | --- |
+| TBD | Genie Code fills | Genie Code fills | Genie Code fills | Genie Code fills | Genie Code fills | Genie Code fills |
+
+### Join Evidence
+
+| Join | Evidence type | Overlap/cardinality result | Confidence | Caveats |
+| --- | --- | --- | --- | --- |
+| TBD | constraint / profiling / query history / user confirmation | Genie Code fills | High / Medium / Low | TBD |
+
+### Metric View Validation
+
+| Metric View | Measures tested | Dimensions tested | `MEASURE()` query status | Semantic gaps |
+| --- | --- | --- | --- | --- |
+| TBD | Genie Code fills | Genie Code fills | not tested / EXPLAIN checked / read-only executed | TBD |
+
+### Per-Question Readiness
+
+| Question | Semantic coverage | Data quality and freshness | Modelability | GenAI context readiness | Overall confidence | Gaps or assumptions |
+| --- | --- | --- | --- | --- | --- | --- |
+| Q1 | High / Medium / Low | High / Medium / Low | High / Medium / Low | High / Medium / Low | High / Medium / Low | TBD |
+| Q2 | High / Medium / Low | High / Medium / Low | High / Medium / Low | High / Medium / Low | High / Medium / Low | TBD |
+| Q3 | High / Medium / Low | High / Medium / Low | High / Medium / Low | High / Medium / Low | High / Medium / Low | TBD |
+
+## Approval Checklist
+
+Before proposing live Genie Space creation or update, confirm:
+
+- [ ] Source set is focused and each attached object supports the Space purpose.
+- [ ] Each priority business question is High or Medium readiness, or Low-confidence limitations are explicit.
+- [ ] Missing metric definitions are confirmed or marked as assumptions.
+- [ ] Missing join relationships are confirmed or marked as assumptions.
+- [ ] Fiscal calendar, timezone, and default filters are confirmed or marked as assumptions.
+- [ ] Read-only validation was performed for examples, joins, snippets, and SQL benchmarks where applicable.
+- [ ] Benchmark SQL uses validated, concrete values and is not copied into sample questions or examples.
+- [ ] Text instructions, if any, are justified as global behavior that structured surfaces cannot encode.
+- [ ] No source data, Unity Catalog object, or Metric View mutation is required.
+- [ ] No live Genie Space creation or update will occur without explicit user approval.

--- a/genie-code/create-genie-space/SPEC.md
+++ b/genie-code/create-genie-space/SPEC.md
@@ -1,298 +1,97 @@
 # Genie Space SPEC.md Template
 
-Use this template before invoking the `create-genie-space` skill when you want a spec-driven Genie Space creation flow.
+Use this template before invoking the `create-genie-space` skill when the customer can provide data artifacts before a working session. Use one `SPEC.md` per Genie Space.
+
+This spec captures only customer decisions and business context. Genie Code should derive schema details, profiling, joins, prompt matching, hidden technical fields, readiness, and proposed Genie Space configuration from the artifacts and approved read-only inspection.
 
 Unknowns may be marked `TBD`. Use fully qualified Unity Catalog identifiers (`catalog.schema.object`) whenever known. Do not paste secrets, tokens, credentials, sensitive free text, or unnecessary raw sample data.
 
-This spec is a design input, not approval to create or update a live Genie Space. Genie Code should complete the profiling and readiness sections only with read-only workspace evidence.
+## 1. Artifact Package
 
-## Space Brief
+Provide these before the workshop:
 
-| Field | Value |
+- `DESCRIBE EXTENDED` output for every table, view, and Metric View.
+- Metric View definition export or copy for every Metric View.
+- Optional: sample rows for tables and standard views.
+- Optional: existing dashboards, SQL, notebooks, known-good answers, data dictionaries, or business glossaries.
+
+Missing artifacts or limitations:
+
+- TBD
+
+## 2. Space Goal
+
+| Field | Customer input |
 | --- | --- |
 | Draft Space title | TBD |
 | Owner/requester | TBD |
+| SME for business questions | TBD |
 | Intended audience | TBD |
 | Primary purpose | TBD |
 | Success criteria | TBD |
-| Expected usage mode | Exploratory Q&A / executive reporting / operational triage / benchmarked validation / mixed |
-| In-scope questions | TBD |
-| Out-of-scope questions | TBD |
-| Security or access caveats | TBD |
+| In scope | TBD |
+| Out of scope | TBD |
+| Draft only or live creation after approval? | draft only / live creation after approval |
 
-## Priority Business Questions
+## 3. Sources And Authority
 
-Capture 3-5 realistic questions the audience will ask. Genie Code fills readiness confidence after profiling.
+List the candidate sources and the business reason each belongs. Do not summarize columns, measures, or dimensions here; Genie Code derives those from the artifacts.
 
-### Question 1
-
-- Business question:
-- Expected answer shape: single number / table / trend / ranking / comparison / narrative synthesis / other
-- Required measures:
-- Required dimensions or groupings:
-- Required filters:
-- Date, fiscal, or timezone logic:
-- Candidate source hints:
-- Benchmark needed: none / SQL answer / Agent evaluation notes / both
-- Readiness confidence (Genie Code fills): High / Medium / Low
-- Readiness notes (Genie Code fills):
-
-### Question 2
-
-- Business question:
-- Expected answer shape:
-- Required measures:
-- Required dimensions or groupings:
-- Required filters:
-- Date, fiscal, or timezone logic:
-- Candidate source hints:
-- Benchmark needed: none / SQL answer / Agent evaluation notes / both
-- Readiness confidence (Genie Code fills): High / Medium / Low
-- Readiness notes (Genie Code fills):
-
-### Question 3
-
-- Business question:
-- Expected answer shape:
-- Required measures:
-- Required dimensions or groupings:
-- Required filters:
-- Date, fiscal, or timezone logic:
-- Candidate source hints:
-- Benchmark needed: none / SQL answer / Agent evaluation notes / both
-- Readiness confidence (Genie Code fills): High / Medium / Low
-- Readiness notes (Genie Code fills):
-
-### Optional Question 4
-
-- Business question:
-- Expected answer shape:
-- Required measures:
-- Required dimensions or groupings:
-- Required filters:
-- Date, fiscal, or timezone logic:
-- Candidate source hints:
-- Benchmark needed: none / SQL answer / Agent evaluation notes / both
-- Readiness confidence (Genie Code fills): High / Medium / Low
-- Readiness notes (Genie Code fills):
-
-### Optional Question 5
-
-- Business question:
-- Expected answer shape:
-- Required measures:
-- Required dimensions or groupings:
-- Required filters:
-- Date, fiscal, or timezone logic:
-- Candidate source hints:
-- Benchmark needed: none / SQL answer / Agent evaluation notes / both
-- Readiness confidence (Genie Code fills): High / Medium / Low
-- Readiness notes (Genie Code fills):
-
-## Candidate Data Sources
-
-Start with a focused set, ideally 5 or fewer objects. Include tables, standard views, and existing Metric Views only.
-
-| Identifier | Type | Business role | Inclusion reason | Known grain | Freshness or SLA | Owner | Caveats |
-| --- | --- | --- | --- | --- | --- | --- | --- |
-| `catalog.schema.object` | table / view / Metric View | TBD | TBD | TBD | TBD | TBD | TBD |
-
-### Metric View Details
-
-Complete this section for each candidate Metric View.
-
-#### `catalog.schema.metric_view`
-
-- Governed measures:
-- Governed dimensions:
-- Built-in filters:
-- Time dimensions:
-- Display names and synonyms:
-- Formatting metadata:
-- Known query pattern using `MEASURE()`:
-- Upstream semantic gaps:
-- Should underlying source tables also be attached? no / yes, because:
-
-### Table And Standard View Details
-
-Complete this section for each candidate table or standard view.
-
-#### `catalog.schema.table_or_view`
-
-- Business description:
-- Grain:
-- Primary time columns:
-- Candidate key columns:
-- Candidate measures:
-- Useful dimensions and filters:
-- Likely joins:
-- Join evidence or confirmation needed:
-- Columns to hide from Genie:
-- Sensitive, noisy, or low-value fields:
-- Data quality caveats already known:
-
-## Business Semantics
-
-### KPI And Metric Definitions
-
-| Name | Definition or formula | Numerator | Denominator | Exclusions | Governed by Metric View? | Confirmation status |
-| --- | --- | --- | --- | --- | --- | --- |
-| TBD | TBD | TBD | TBD | TBD | yes / no | confirmed / needs confirmation / TBD |
-
-### Calendar, Time, And Defaults
-
-- Fiscal calendar:
-- Timezone:
-- Default date range:
-- Default filters:
-- Default currency or units:
-- Rounding or formatting conventions:
-
-### Terminology
-
-| User term | Meaning | Maps to source, column, measure, or value | Preferred interpretation | Confirmation status |
-| --- | --- | --- | --- | --- |
-| TBD | TBD | TBD | TBD | confirmed / needs confirmation / TBD |
-
-### Ambiguities To Resolve
-
-- Ambiguous metric definitions:
-- Ambiguous joins:
-- Ambiguous filters or segment definitions:
-- Terms that may mean different things to different users:
-
-## Genie Space Design Decisions
-
-Genie Code should prefer structured configuration surfaces over broad text instructions.
-
-### Data Sources To Attach
-
-| Identifier | Attach? | Reason | Questions supported | Limitations |
-| --- | --- | --- | --- | --- |
-| `catalog.schema.object` | yes / no / TBD | TBD | TBD | TBD |
-
-### Metadata And Synonyms
-
-- Space or source descriptions to add:
-- Column descriptions to add:
-- Metric View data-source descriptions to add in the Genie Space:
-- Column or measure synonyms:
-- Display-name conventions:
-
-### Prompt Matching And Entity Matching
-
-List categorical string fields users are likely to mention directly. Genie Code should verify eligibility, cardinality, and useful values before enabling.
-
-| Source | Column | User-facing values or terms | Enable format assistance? | Enable entity matching? | Evidence |
+| Source identifier | Type | Why include it? | Authoritative for | Owner/SME | Caveats |
 | --- | --- | --- | --- | --- | --- |
-| TBD | TBD | TBD | yes / no / TBD | yes / no / TBD | Genie Code fills |
+| `catalog.schema.object` | table / view / Metric View | TBD | TBD | TBD | TBD |
 
-### Hidden Fields
+Source preference rules:
 
-List ingestion metadata, audit fields, hashes, raw JSON, embeddings, secrets, sensitive free text, unused PII, and other fields that should be hidden from end-user context.
+- If sources overlap, which one should Genie prefer?
+- Should raw/detail tables be exposed alongside Metric Views? If yes, for what questions?
+- Are any sources staging, deprecated, incomplete, or included only for lookup/enrichment?
 
-| Source | Column | Reason to hide | Confirmed? |
+## 4. Question And Benchmark Inputs
+
+Provide real analyst questions from customer users or SMEs. Genie Code uses 3-5 questions to understand what the Space is about and derive the initial Space design.
+
+For benchmark analysis, provide at least 15 questions; about 30 is ideal. If fewer than 15 questions are provided, Genie Code can still draft the Space, but benchmark analysis should be treated as incomplete.
+
+Do not require the customer to provide benchmark SQL unless they already have known-good SQL, dashboard logic, or expected results.
+
+| # | Benchmark question | Optional ground-truth SQL | Evaluation notes |
 | --- | --- | --- | --- |
-| TBD | TBD | TBD | yes / no / TBD |
+| 1 | TBD | TBD | TBD |
+| 2 | TBD | TBD | TBD |
+| 3 | TBD | TBD | TBD |
 
-### Joins
+Repeat rows as needed.
 
-Only include joins supported by constraints, profiling, query history, naming evidence, or user confirmation.
+## 5. Business Semantics
 
-| Left source and key | Right source and key | Relationship | Business meaning | Evidence required or observed |
-| --- | --- | --- | --- | --- |
-| TBD | TBD | many-to-one / one-to-many / one-to-one / many-to-many / TBD | TBD | TBD |
+Fill only definitions or conventions that are not already governed by a Metric View, or that require confirmation.
 
-### SQL Snippets, Examples, Functions, And Text Instructions
+- KPI definitions or formulas:
+- Fiscal calendar and timezone:
+- Default date range or comparison period:
+- Default filters, exclusions, or active/inactive logic:
+- Ambiguous terms, acronyms, statuses, or segments:
+- Currency, units, rounding, or formatting expectations:
 
-- Reusable filter snippets:
-- Reusable expression snippets:
-- Reusable measure snippets:
-- Example SQL patterns needed for complex questions:
-- SQL functions to expose, if any:
-- Text instructions needed for global behavior only:
+## 6. Security And Caveats
 
-If text instructions are proposed, include:
+List business-sensitive or policy details the artifacts may not reveal.
 
-```markdown
-## Text Instruction Justification
+- PII or sensitive business fields:
+- Fields technically available but inappropriate for the audience:
+- Row-level security, masks, or dynamic view caveats:
+- Known data quality or freshness issues:
+- Required caveats Genie should surface to users:
 
-- Exact instruction text:
-- Why structured surfaces were insufficient:
-- Intended global behavior:
-- Possible overreach or regression risk:
-- How the instruction will be reviewed or validated:
-```
+## 7. Validation And Approval
 
-## Sample Questions And Benchmarks
+- Final approver:
+- Approval criteria:
+- Target workspace/path, if live creation is approved:
 
-### Sample Questions
+No live Genie Space creation or update should happen until the customer explicitly approves the proposed configuration in Databricks.
 
-Sample questions should be user-facing starting points, not copied benchmark tests.
+## Genie Code Should Derive
 
-1. TBD
-2. TBD
-3. TBD
-4. TBD
-5. TBD
-
-### Benchmark Candidates
-
-Benchmark literals, parameter defaults, and expected SQL should use profiled values. Do not invent statuses, regions, categories, dates, or IDs. Do not copy benchmark answer SQL into example SQL.
-
-| Question | Target mode | Expected answer strategy | Sources and logic covered | Validation status |
-| --- | --- | --- | --- | --- |
-| TBD | SQL answer / Agent evaluation notes / both | TBD | TBD | not validated / EXPLAIN checked / read-only executed |
-
-## Profiling And Readiness Evidence
-
-Genie Code fills this section during read-only inspection.
-
-### Read-Only Validation Performed
-
-- Metadata inspected:
-- SQL commands used:
-- Queries executed or explained:
-- System lineage/query history checked:
-- Limitations:
-
-### Source Profiling Summary
-
-| Source | Row count | Grain | Freshness/date range | Key quality notes | Useful categorical values | Sensitive/noisy fields |
-| --- | --- | --- | --- | --- | --- | --- |
-| TBD | Genie Code fills | Genie Code fills | Genie Code fills | Genie Code fills | Genie Code fills | Genie Code fills |
-
-### Join Evidence
-
-| Join | Evidence type | Overlap/cardinality result | Confidence | Caveats |
-| --- | --- | --- | --- | --- |
-| TBD | constraint / profiling / query history / user confirmation | Genie Code fills | High / Medium / Low | TBD |
-
-### Metric View Validation
-
-| Metric View | Measures tested | Dimensions tested | `MEASURE()` query status | Semantic gaps |
-| --- | --- | --- | --- | --- |
-| TBD | Genie Code fills | Genie Code fills | not tested / EXPLAIN checked / read-only executed | TBD |
-
-### Per-Question Readiness
-
-| Question | Semantic coverage | Data quality and freshness | Modelability | GenAI context readiness | Overall confidence | Gaps or assumptions |
-| --- | --- | --- | --- | --- | --- | --- |
-| Q1 | High / Medium / Low | High / Medium / Low | High / Medium / Low | High / Medium / Low | High / Medium / Low | TBD |
-| Q2 | High / Medium / Low | High / Medium / Low | High / Medium / Low | High / Medium / Low | High / Medium / Low | TBD |
-| Q3 | High / Medium / Low | High / Medium / Low | High / Medium / Low | High / Medium / Low | High / Medium / Low | TBD |
-
-## Approval Checklist
-
-Before proposing live Genie Space creation or update, confirm:
-
-- [ ] Source set is focused and each attached object supports the Space purpose.
-- [ ] Each priority business question is High or Medium readiness, or Low-confidence limitations are explicit.
-- [ ] Missing metric definitions are confirmed or marked as assumptions.
-- [ ] Missing join relationships are confirmed or marked as assumptions.
-- [ ] Fiscal calendar, timezone, and default filters are confirmed or marked as assumptions.
-- [ ] Read-only validation was performed for examples, joins, snippets, and SQL benchmarks where applicable.
-- [ ] Benchmark SQL uses validated, concrete values and is not copied into sample questions or examples.
-- [ ] Text instructions, if any, are justified as global behavior that structured surfaces cannot encode.
-- [ ] No source data, Unity Catalog object, or Metric View mutation is required.
-- [ ] No live Genie Space creation or update will occur without explicit user approval.
+Do not ask the customer to pre-fill these unless they already have the answer: source profiling, row counts, grain, freshness, column descriptions, Metric View measure/dimension review, prompt/entity matching candidates, hidden technical fields, join evidence, SQL snippets, example SQL, text-instruction justification, benchmark SQL, and per-question readiness.


### PR DESCRIPTION
## Summary
- Added a root-level `genie-code/create-genie-space/SPEC.md` template for spec-driven Genie Space creation.
- Updated `genie-code/create-genie-space/SKILL.md` so Genie Code reads a completed spec, or the template when no spec is provided.

## Testing
- Ran the local skill validation check for `genie-code/create-genie-space`.
- Validation passed.