### PR TITLE
P1: Genie Space History MCP — server core (write + read)

### DIFF
--- a/genie-code/genie-space-history-mcp-design.md
+++ b/genie-code/genie-space-history-mcp-design.md
@@ -151,7 +151,7 @@ These facts (from the investigation) directly constrain the design. Confidence +
 
 | #   | Tool                      | Purpose                                                                                                            | Key inputs                                                                                                                                                       | Returns                                                                   |
 | --- | ------------------------- | ------------------------------------------------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------- |
-| 1   | `save_config_snapshot`    | Persist a Genie Space config version (the mandatory before/after snapshot). The caller supplies the config — the MCP does **not** fetch it.                                        | `space_id`, `serialized_space` (**required** — caller passes the live config), `etag?`, `version_label`, `parent_config_version_id`, `run_id?`, `changed_surfaces?`, `change_summary?`, `rollback_reference?` | `config_version_id`, `version`, `config_hash`, `etag`                     |
+| 1   | `save_config_snapshot`    | Persist a Genie Space config version (the mandatory before/after snapshot). The caller supplies the config — the MCP does **not** fetch it.                                        | `space_id`, `serialized_space` (**required** — caller passes the live config), `etag?`, `version_label`, `parent_config_version_id`, `run_id?`, `changed_surfaces?`, `change_summary?`, `rollback_reference?` | `config_version_id`, `config_hash`, `etag`                     |
 | 2   | `save_report`             | Persist a Markdown artifact (diagnose write-up, query-optimization report, design proposal, metric-view YAML/DDL). | `space_id`, `artifact_type`, `title`, `content_md`, `run_id?`, `scores_findings?`                                                                                | `artifact_id`                                                             |
 | 3   | `record_optimization_run` | Persist a tuning run: run summary + per-question eval results + decision (the `runs/` + `eval_results/` records).  | `space_id`, `run_id`, run fields (see §7), `eval_results[]`, `decision`                                                                                          | `run_id`                                                                  |
 | 4   | `list_history`            | Timeline of versions/runs/reports for a Space.                                                                     | `space_id`, `artifact_type?`, `limit?`, `since?`                                                                                                                 | array of `{id, type, version, created_at, created_by, summary, decision}` |
@@ -168,6 +168,7 @@ These facts (from the investigation) directly constrain the design. Confidence +
 - All inputs validated against the field contracts in §7; reject unknown `artifact_type`. Writes **route to the per-artifact table** (§7.1); `list_history` UNIONs across the tables and `get_artifact` resolves an id across them.
 - Idempotency: `save_*` accepts a client-supplied `idempotency_key` (e.g. `config_hash`) to avoid duplicate rows on retry.
 - Rollback has **no MCP tool**: the skill retrieves the target via `get_artifact`, re-applies it through Genie Code's own Space-edit path, and records the result via `save_config_snapshot` (see §8).
+- **`version` in outputs (P1):** `save_config_snapshot` no longer returns a `version`; the `version` key still present in each `list_history` row is **retained for output-shape stability but is always `null`** — the monotonic counter was removed (§7.1). Order results by `created_at`.
 
 ---
 
@@ -185,9 +186,8 @@ The schema **deliberately aligns with `optimize-genie-space/references/optimizat
 CREATE TABLE IF NOT EXISTS ${HISTORY_CATALOG}.genie_space_history.config_snapshots (
   config_version_id   STRING    NOT NULL,        -- 32-char hex UUID, logical PK
   space_id            STRING    NOT NULL,
-  version             BIGINT    NOT NULL,         -- monotonic per space_id (1,2,3…)
   parent_version_id   STRING,                     -- parent_config_version_id → rollback lineage
-  created_at          TIMESTAMP DEFAULT current_timestamp(),
+  created_at          TIMESTAMP DEFAULT current_timestamp(),  -- ordering/identity key: list_history sorts created_at DESC, config_version_id ASC
   created_by          STRING    DEFAULT current_user(),  -- attribution + row-filter key
   skill_name          STRING,
   config_json         STRING,                     -- JSON serialized_space; opt-in VARIANT on DBR >= 15.3
@@ -200,6 +200,8 @@ CREATE TABLE IF NOT EXISTS ${HISTORY_CATALOG}.genie_space_history.config_snapsho
   change_summary      STRING
 ) USING DELTA TBLPROPERTIES (delta.enableRowTracking = true);
 ```
+
+> **P1 update — no monotonic `version` column.** Earlier drafts gave `config_snapshots` a `version BIGINT` counter (`MAX(version)+1` per `space_id`). A UC SQL warehouse has no atomic insert-if-absent, no enforced unique/PK constraint, and no multi-statement transaction, so concurrent writers could allocate the **same** version — a uniqueness guarantee the code could not actually hold. P1 therefore **drops the counter**: each snapshot is identified by `config_version_id` (UUID PK) and ordered by the server-stamped `created_at` (`list_history` sorts `created_at DESC, config_version_id ASC`). Lineage uses `parent_version_id` (a `config_version_id`), never a counter; idempotency uses a client-supplied `idempotency_key`. *(Delivered in PR #23.)*
 
 **(2) `optimization_runs`** — one row per tuning run (mirrors the skill's `runs/`).
 
@@ -321,7 +323,7 @@ Optimistic concurrency is a **body `etag` field** (not an `If-Match` header): Ge
 
 **Flow (snapshot owned by the MCP; apply owned by Genie Code):**
 
-1. **Snapshot first (enforced by the skill).** Before any edit, `optimize-genie-space` reads the live config (it already does this to edit it) and calls **`save_config_snapshot`**, passing `serialized_space` + the Space `etag` + `config_hash`. The MCP stores them and computes `version`/lineage. The skill's hard rule stands: refuse to edit if the snapshot didn't persist.
+1. **Snapshot first (enforced by the skill).** Before any edit, `optimize-genie-space` reads the live config (it already does this to edit it) and calls **`save_config_snapshot`**, passing `serialized_space` + the Space `etag` + `config_hash`. The MCP stores them and computes lineage (no monotonic version counter — see §7.1). The skill's hard rule stands: refuse to edit if the snapshot didn't persist.
 2. **Lineage.** `parent_version_id` + `run_id` + `baseline/candidate` pointers reconstruct the version DAG (server-side, from the stored rows).
 3. **Restore (on a ROLL BACK decision) — driven by Genie Code:**
   - **`get_artifact(config_version_id)`** → the stored `serialized_space` (+ outer metadata + `etag`). *(Optional preview: `diff_configs`, or two `get_artifact` calls, show the change before applying.)*
@@ -415,6 +417,13 @@ Integration is **opt-in and additive**: skills detect the MCP server's tools and
   >
   > **Still open for the real build:** create the durable `HISTORY_OWNER_GROUP` and add the app SP to it (or have a metastore admin run the one-time `OWNER TO`); grant the app SP on the catalog; authorize `user_api_scopes` (`sql`); settle private-vs-shared history (§5). *(No longer the MCP's concern under Option A: the minimum Genie permission and stale-etag behavior — those live with Genie Code's apply path.)*
 - **P1 — Write + read:** `save_config_snapshot`, `save_report`, `list_history`, `get_artifact` against the UC table (OBO + row filter). Wire `diagnose`/`optimize-query` reports.
+  > **P1 OUTCOME — delivered in [PR #23](https://github.com/hiydavid/databricks-agent-skills/pull/23) (`genie-code/mcp-genie-space-history/app/`); built by a coding agent, cross-reviewed by a different vendor, gates green (pytest / ruff / pyright):**
+  >
+  > - ✅ Production `app/` package: OBO auth + app-SP bootstrap, UC storage adapter, idempotent provisioning of all 7 §7.1 tables with the `only_mine` row filter (a grant is **withheld** on any table whose filter did not apply) + ownership/grants, `STRING`-default JSON (VARIANT opt-in), `allowColumnDefaults`.
+  > - ✅ All four tools, OBO throughout; writes stamp `created_by`/`created_at` server-side; `redact` defaults true; unknown `artifact_type` rejected; `scope_error` on missing scope / identity-auth failure.
+  > - ✅ **Concurrency decision:** dropped the monotonic `version` counter — snapshots are ordered/identified by `created_at` + `config_version_id` (§7.1); idempotency via a client `idempotency_key`.
+  > - ⚠️ **No schema migration:** provisioning is `CREATE TABLE IF NOT EXISTS` only. Fresh deploys are correct, but a `config_snapshots` table created by the old spike bootstrap still has `version BIGINT NOT NULL` and must have that column dropped (or the table recreated) before deploying P1.
+  > - **Scope:** 'Wire diagnose/optimize-query' = server-side support for the `diagnose_report` + `query_report` artifact types via `save_report`; the per-skill `SKILL.md` text edits remain **P5** (docs-only).
 - **P2 — Runs + rollback wiring:** `record_optimization_run`. Wire `optimize-genie-space`'s snapshot + run + rollback calls — rollback = `get_artifact` the target snapshot, the **skill** re-applies it, then `save_config_snapshot` the result (the MCP has **no** rollback tool).
 - **P3 — Polish:** `diff_configs`, redaction defaults, observability. *(Self-serve / DABs packaging is promoted to its own phase — see P4.)*
 - **P4 — Packaging & self-serve deploy.** Turn the working server into something an operator can deploy **themselves, from git, onto Databricks Apps** with minimal hand-holding. Goal: a clone → configure → deploy path plus the operator runbook for the human-only grant/ownership steps the server cannot self-perform. Deliverables:

--- a/genie-code/mcp-genie-space-history/app/.gitignore
+++ b/genie-code/mcp-genie-space-history/app/.gitignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.pyc
+.venv/
+.ruff_cache/
+.pytest_cache/
+*.egg-info/
+uv.lock
+.databricks/
+.env
+.env.*

--- a/genie-code/mcp-genie-space-history/app/README.md
+++ b/genie-code/mcp-genie-space-history/app/README.md
@@ -42,13 +42,17 @@ server/
 ## Identity & auth (spec §5)
 
 - **OBO for all reads/writes.** A fresh `WorkspaceClient` is built per request from
-  the `X-Forwarded-Access-Token` header (never cached). `created_by` is stamped from
-  `current_user.me()`; `created_at` is server-side (`current_timestamp()`).
+  the `X-Forwarded-Access-Token` header (never cached). `created_by` and `created_at`
+  are stamped **server-side** via SQL `current_user()` / `current_timestamp()`, so
+  `created_by` always equals the `SESSION_USER()` the `only_mine` row filter compares
+  against (a user can always read back their own writes).
 - **App SP for bootstrap/admin only** — provisioning. Never the write actor for a
   user artifact; the server **never silently falls back to the SP** for a user write.
-- On a missing token / disabled OBO / missing `sql` scope, tools return a structured
-  `scope_error` telling the user to enable the `sql` scope (`OBO_ENABLED` is a feature
-  flag for graceful degradation where OBO isn't enabled yet).
+- On a missing token / disabled OBO / missing `sql` scope — including a token/identity
+  auth failure (SDK `Unauthenticated`/401) while resolving the caller — tools return a
+  structured `scope_error` telling the user to enable the `sql` scope. A UC grant denial
+  (`PERMISSION_DENIED`/403) is deliberately **not** relabeled a scope error. `OBO_ENABLED`
+  is a feature flag for graceful degradation where OBO isn't enabled yet.
 
 ## Configuration (env — see `app.yaml`)
 
@@ -69,15 +73,42 @@ The schema name is fixed at `genie_space_history`. `app.yaml` declares
 
 On startup inside a deployed App, the SP idempotently: creates the schema + all 7
 tables (with `delta.enableRowTracking` + `delta.feature.allowColumnDefaults`), creates
-`only_mine`, applies the row filter to each table, grants `HISTORY_GRANTEE`, keeps the
-SP's own `SELECT`/`MODIFY`, then reassigns `OWNER TO HISTORY_OWNER_GROUP`. The
-**catalog is never created**. Ownership reassignment **may fail** if the SP isn't a
-member of the owner group — that is captured as a structured WARNING and startup
-continues (an operator/metastore admin runs the one-time `OWNER TO`).
+`only_mine`, and applies the row filter to each table. **Row isolation is required, not
+best-effort:** `HISTORY_GRANTEE` is granted `SELECT`/`MODIFY` **per table, only on
+tables whose row filter actually applied** (never schema-wide). If the `only_mine`
+function or any table's filter fails, that table's grant is **withheld** and
+`report["ok"]` is `False` — the grantee can never reach an unfiltered table. The SP
+keeps its own per-table `SELECT`/`MODIFY`. **Only** the final `OWNER TO
+HISTORY_OWNER_GROUP` reassignment may warn-and-continue (it legitimately fails if the
+SP isn't a member of the owner group; an operator/metastore admin runs the one-time
+`OWNER TO`). The **catalog is never created**, and startup never crashes.
 
 **Operator prerequisites the app cannot self-perform** (spec §10): grant the app SP
 `USE CATALOG` + `CREATE SCHEMA` on `HISTORY_CATALOG`; create/join `HISTORY_OWNER_GROUP`;
 confirm OBO is enabled in the Previews portal.
+
+## Concurrency & idempotency (spec §6/§11)
+
+UC SQL warehouses enforce **no** PK/unique constraints or row locks, and give the app
+no multi-statement transaction. `save_config_snapshot` therefore cannot make
+`MAX(version)+1 → INSERT` atomic. It uses a bounded **optimistic-retry**:
+
+1. **Idempotency** — the logical id is derived deterministically from the idempotency
+   key (which defaults to `config_hash`). A read-before-write returns the existing row
+   on a repeat key, so a sequential retry never inserts a second row.
+2. **Version monotonicity** — after inserting, the write verifies no *other* config
+   grabbed the same `version`. On a collision the writers tie-break by id (the larger id
+   backs out its row via `DELETE` and retries with a freshly computed version); after
+   `MAX_SAVE_ATTEMPTS` it surfaces a clean `contention` error rather than leaving a
+   colliding row.
+
+**Residual race (documented, not silently ignored):** two writes issued *simultaneously*
+with the **same idempotency key** can each pass read-before-write and land byte-identical
+rows; a targeted `DELETE` can't distinguish them, so a transient duplicate may persist —
+the logical result returned is still single and correct. The normal skill path is a
+single writer per `(space, user)` and is unaffected. A fully race-free guarantee is not
+achievable on UC SQL-warehouse semantics in P1; closing it would need a serializing
+mechanism (e.g. a Lakebase/transactional sequence) — out of P1 scope.
 
 ## Dev inner loop
 

--- a/genie-code/mcp-genie-space-history/app/README.md
+++ b/genie-code/mcp-genie-space-history/app/README.md
@@ -1,0 +1,102 @@
+# Genie Space History MCP — server (`app/`)
+
+Production server for the Genie Space History MCP, deployed on **Databricks Apps**
+and mounted at **`/mcp`** over stateless streamable HTTP. It persists the artifacts
+the `genie-code/` skills emit to governed **Unity Catalog Delta tables** and serves
+them back. The MCP **never calls the Genie API** — it only touches UC (Option A).
+
+This is the **P1 (write + read)** slice. The immutable P0 spike lives alongside in
+[`../spike/`](../spike); the authoritative design is
+[`../../genie-space-history-mcp-design.md`](../../genie-space-history-mcp-design.md).
+
+## What ships in P1
+
+Four MCP tools (spec §6), all running **On-Behalf-Of-User (OBO)**:
+
+| Tool | Purpose | Writes |
+| --- | --- | --- |
+| `save_config_snapshot` | Persist a Space config version (the rollback-critical snapshot). Server computes a monotonic per-`space_id` `version`, a sha256 `config_hash`, stores the caller's `etag` verbatim, sets lineage via `parent_config_version_id`. | `config_snapshots` |
+| `save_report` | Persist a Markdown artifact, routed by `artifact_type` (`diagnose_report` / `query_report` / `design_proposal` / `metric_view_ddl`); unknown types rejected; `redacted` defaults to `true`. | the routed report table |
+| `list_history` | Timeline for a Space — UNION across all artifact tables; optional `artifact_type` / `since` filters. | — |
+| `get_artifact` | Resolve a `config_version_id` / `artifact_id` / `run_id` across all tables and return the full record. | — |
+
+> `record_optimization_run` (P2) is **out of scope**, but `optimization_runs` /
+> `eval_results` tables still exist and `list_history` / `get_artifact` span them.
+
+## Module layout (`server/`)
+
+```
+server/
+├── config.py        # env-driven Settings (spec §10)
+├── errors.py        # structured scope_error / validation_error payloads (spec §5)
+├── sql.py           # exec_sql + identifier quoting + Param/QueryResult adapter (spec §11)
+├── schema.py        # DDL for the 7 tables + only_mine row-filter function (spec §7.1)
+├── auth.py          # OBO (per-request user) vs app-SP WorkspaceClient builders (spec §5)
+├── provisioning.py  # idempotent startup bootstrap: schema/tables/filter/ownership/grants
+├── store.py         # UCTableStore — server-side bound params, versioning, dedupe, list/get
+├── tools.py         # the four P1 MCP tools + OBO/error wrapping
+├── app.py           # FastAPI + FastMCP mount at /mcp, CORS, OBO middleware, lifespan bootstrap
+└── main.py          # uvicorn entrypoint (binds DATABRICKS_APP_PORT)
+```
+
+## Identity & auth (spec §5)
+
+- **OBO for all reads/writes.** A fresh `WorkspaceClient` is built per request from
+  the `X-Forwarded-Access-Token` header (never cached). `created_by` is stamped from
+  `current_user.me()`; `created_at` is server-side (`current_timestamp()`).
+- **App SP for bootstrap/admin only** — provisioning. Never the write actor for a
+  user artifact; the server **never silently falls back to the SP** for a user write.
+- On a missing token / disabled OBO / missing `sql` scope, tools return a structured
+  `scope_error` telling the user to enable the `sql` scope (`OBO_ENABLED` is a feature
+  flag for graceful degradation where OBO isn't enabled yet).
+
+## Configuration (env — see `app.yaml`)
+
+| Var | Meaning |
+| --- | --- |
+| `HISTORY_CATALOG` | **Pre-existing** UC catalog. The app **NEVER** creates it. |
+| `HISTORY_OWNER_GROUP` | Durable account group that OWNS the schema/tables (survives app/SP deletion). |
+| `HISTORY_GRANTEE` | User group granted `SELECT`/`MODIFY` for OBO reads/writes. |
+| `SQL_WAREHOUSE_ID` | Warehouse all UC SQL runs on (bind a `sql-warehouse` app resource). |
+| `CORS_ALLOW_ORIGINS` | Comma-separated workspace origin allowlist. |
+| `HISTORY_USE_VARIANT` | Opt-in VARIANT JSON columns (default `false` → STRING; spec §7.1/§12 #3). |
+| `OBO_ENABLED` | OBO feature flag (default `true`). |
+
+The schema name is fixed at `genie_space_history`. `app.yaml` declares
+`user_api_scopes: sql` (required, P0 finding F-6).
+
+## Startup bootstrap (app SP, idempotent — spec §7.1/§10)
+
+On startup inside a deployed App, the SP idempotently: creates the schema + all 7
+tables (with `delta.enableRowTracking` + `delta.feature.allowColumnDefaults`), creates
+`only_mine`, applies the row filter to each table, grants `HISTORY_GRANTEE`, keeps the
+SP's own `SELECT`/`MODIFY`, then reassigns `OWNER TO HISTORY_OWNER_GROUP`. The
+**catalog is never created**. Ownership reassignment **may fail** if the SP isn't a
+member of the owner group — that is captured as a structured WARNING and startup
+continues (an operator/metastore admin runs the one-time `OWNER TO`).
+
+**Operator prerequisites the app cannot self-perform** (spec §10): grant the app SP
+`USE CATALOG` + `CREATE SCHEMA` on `HISTORY_CATALOG`; create/join `HISTORY_OWNER_GROUP`;
+confirm OBO is enabled in the Previews portal.
+
+## Dev inner loop
+
+```bash
+cd genie-code/mcp-genie-space-history/app
+
+# Tests (no live workspace needed — the SQL layer is mocked)
+python -m pytest
+
+# Lint + format check
+uvx ruff check .
+uvx ruff format --check .
+
+# Typecheck (deps installed alongside pyright so imports resolve)
+uvx --with databricks-sdk --with fastapi --with fastmcp --with "mcp[cli]" \
+    --with pydantic --with uvicorn --with pytest pyright
+
+# Run locally (uses your Databricks CLI default creds; OBO is App-only)
+uvicorn server.app:app --port 8000
+```
+
+Self-serve / DABs packaging is **P4** (out of scope here).

--- a/genie-code/mcp-genie-space-history/app/README.md
+++ b/genie-code/mcp-genie-space-history/app/README.md
@@ -15,7 +15,7 @@ Four MCP tools (spec §6), all running **On-Behalf-Of-User (OBO)**:
 
 | Tool | Purpose | Writes |
 | --- | --- | --- |
-| `save_config_snapshot` | Persist a Space config version (the rollback-critical snapshot). Server computes a monotonic per-`space_id` `version`, a sha256 `config_hash`, stores the caller's `etag` verbatim, sets lineage via `parent_config_version_id`. | `config_snapshots` |
+| `save_config_snapshot` | Persist a Space config snapshot (the rollback-critical snapshot). Server computes a sha256 `config_hash`, stores the caller's `etag` verbatim, sets lineage via `parent_config_version_id`. Snapshots are ordered/identified by `created_at` + `config_version_id` (no monotonic version counter). | `config_snapshots` |
 | `save_report` | Persist a Markdown artifact, routed by `artifact_type` (`diagnose_report` / `query_report` / `design_proposal` / `metric_view_ddl`); unknown types rejected; `redacted` defaults to `true`. | the routed report table |
 | `list_history` | Timeline for a Space — UNION across all artifact tables; optional `artifact_type` / `since` filters. | — |
 | `get_artifact` | Resolve a `config_version_id` / `artifact_id` / `run_id` across all tables and return the full record. | — |
@@ -33,7 +33,7 @@ server/
 ├── schema.py        # DDL for the 7 tables + only_mine row-filter function (spec §7.1)
 ├── auth.py          # OBO (per-request user) vs app-SP WorkspaceClient builders (spec §5)
 ├── provisioning.py  # idempotent startup bootstrap: schema/tables/filter/ownership/grants
-├── store.py         # UCTableStore — server-side bound params, versioning, dedupe, list/get
+├── store.py         # UCTableStore — server-side bound params, idempotent dedupe, list/get
 ├── tools.py         # the four P1 MCP tools + OBO/error wrapping
 ├── app.py           # FastAPI + FastMCP mount at /mcp, CORS, OBO middleware, lifespan bootstrap
 └── main.py          # uvicorn entrypoint (binds DATABRICKS_APP_PORT)
@@ -90,25 +90,22 @@ confirm OBO is enabled in the Previews portal.
 ## Concurrency & idempotency (spec §6/§11)
 
 UC SQL warehouses enforce **no** PK/unique constraints or row locks, and give the app
-no multi-statement transaction. `save_config_snapshot` therefore cannot make
-`MAX(version)+1 → INSERT` atomic. It uses a bounded **optimistic-retry**:
+no multi-statement transaction. Rather than fight that, `save_config_snapshot` carries
+**no monotonic version counter** — there is nothing to contend on:
 
-1. **Idempotency** — the logical id is derived deterministically from the idempotency
-   key (which defaults to `config_hash`). A read-before-write returns the existing row
-   on a repeat key, so a sequential retry never inserts a second row.
-2. **Version monotonicity** — after inserting, the write verifies no *other* config
-   grabbed the same `version`. On a collision the writers tie-break by id (the larger id
-   backs out its row via `DELETE` and retries with a freshly computed version); after
-   `MAX_SAVE_ATTEMPTS` it surfaces a clean `contention` error rather than leaving a
-   colliding row.
+- **Ordering & identity** come from the server-stamped `created_at` plus the
+  `config_version_id` primary key. `list_history` orders `created_at DESC` with `id` as a
+  stable secondary tiebreaker, so pagination / `since` stay deterministic even when two
+  rows share a timestamp.
+- **A save is a single `INSERT`** — no `MAX(version)` read, no post-insert reconciliation,
+  no back-out `DELETE`. Two rapid snapshots for the same space simply land as two distinct
+  rows.
+- **Idempotency** — the logical id is derived deterministically from the idempotency key
+  (which defaults to `config_hash`). A read-before-write returns the existing row on a
+  repeat key, so a retried save never inserts a second row.
 
-**Residual race (documented, not silently ignored):** two writes issued *simultaneously*
-with the **same idempotency key** can each pass read-before-write and land byte-identical
-rows; a targeted `DELETE` can't distinguish them, so a transient duplicate may persist —
-the logical result returned is still single and correct. The normal skill path is a
-single writer per `(space, user)` and is unaffected. A fully race-free guarantee is not
-achievable on UC SQL-warehouse semantics in P1; closing it would need a serializing
-mechanism (e.g. a Lakebase/transactional sequence) — out of P1 scope.
+Dropping the counter removes the version-allocation race (and its false uniqueness
+guarantee) by construction (cross-review B1).
 
 ## Dev inner loop
 

--- a/genie-code/mcp-genie-space-history/app/app.yaml
+++ b/genie-code/mcp-genie-space-history/app/app.yaml
@@ -1,0 +1,34 @@
+# Databricks Apps manifest for the Genie Space History MCP server (spec §10).
+# App name must start with "mcp-" for AI Playground / Genie Code recognition.
+#
+# Deploy root is this `app/` directory: uvicorn resolves `server.app:app` against
+# it (the `server` package is on sys.path), and Apps installs `requirements.txt`.
+command:
+  - "sh"
+  - "-c"
+  - "uvicorn server.app:app --host 0.0.0.0 --port ${DATABRICKS_APP_PORT:-8000}"
+
+# OBO OAuth scopes (spec §5 / §12 #2, P0 finding F-6). A deployed app's OBO token
+# otherwise defaults to identity-only scopes and warehouse calls fail. This server
+# needs ONLY `sql` (it never calls the Genie API under Option A).
+user_api_scopes:
+  - sql
+
+env:
+  - name: HISTORY_CATALOG
+    value: "<pre-existing-catalog>"   # the app NEVER creates this; schema genie_space_history is auto-created inside it
+  - name: HISTORY_OWNER_GROUP
+    value: "<account-group>"          # durable OWNER of schema/tables (survives app/SP deletion)
+  - name: HISTORY_GRANTEE
+    value: "<user-group>"             # OBO users granted SELECT/MODIFY at bootstrap
+  - name: SQL_WAREHOUSE_ID
+    valueFrom: "sql-warehouse"        # bind a SQL-warehouse app resource (CAN USE)
+  - name: CORS_ALLOW_ORIGINS
+    value: "https://<workspace-host>"  # allow-list the workspace URL (spec §3)
+  # JSON columns default to STRING; flip to true ONLY after confirming VARIANT on the
+  # target warehouse (spec §7.1 / §12 #3). Never hard-required.
+  - name: HISTORY_USE_VARIANT
+    value: "false"
+  # OBO feature flag for graceful degradation where OBO isn't enabled yet (spec §5).
+  - name: OBO_ENABLED
+    value: "true"

--- a/genie-code/mcp-genie-space-history/app/pyproject.toml
+++ b/genie-code/mcp-genie-space-history/app/pyproject.toml
@@ -1,0 +1,42 @@
+# Local dev tooling config (lint + typecheck + tests). Databricks Apps installs
+# requirements.txt at deploy; this file is for the dev inner loop and CI (P4).
+[project]
+name = "mcp-genie-space-history"
+version = "0.1.0"
+description = "Genie Space History MCP server (P1 — write + read) on Databricks Apps"
+requires-python = ">=3.11"
+dependencies = [
+    "databricks-sdk>=0.118.0",
+    "fastapi>=0.115.12",
+    "uvicorn>=0.34.2",
+    "fastmcp>=2.12.5",
+    "mcp[cli]>=1.14.0",
+    "pydantic>=2",
+]
+
+[dependency-groups]
+dev = [
+    "pytest>=8",
+    "ruff>=0.6",
+    "pyright>=1.1.380",
+]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+# Imports, pyflakes (unused/undefined), bare-except, pycodestyle errors.
+select = ["I", "F", "E", "W", "B"]
+
+[tool.pyright]
+include = ["server", "tests"]
+pythonVersion = "3.11"
+typeCheckingMode = "basic"
+reportMissingImports = "warning"
+
+[tool.pytest.ini_options]
+# Make the `server` package importable when running pytest from this directory.
+pythonpath = ["."]
+testpaths = ["tests"]
+addopts = "-q"

--- a/genie-code/mcp-genie-space-history/app/pyproject.toml
+++ b/genie-code/mcp-genie-space-history/app/pyproject.toml
@@ -9,8 +9,9 @@ dependencies = [
     "databricks-sdk>=0.118.0",
     "fastapi>=0.115.12",
     "uvicorn>=0.34.2",
-    "fastmcp>=2.12.5",
-    "mcp[cli]>=1.14.0",
+    # Major-pinned: 2.x and 3.x have incompatible APIs — keep installs deterministic.
+    "fastmcp>=3.4,<4",
+    "mcp[cli]>=1.14.0,<2",
     "pydantic>=2",
 ]
 

--- a/genie-code/mcp-genie-space-history/app/requirements.txt
+++ b/genie-code/mcp-genie-space-history/app/requirements.txt
@@ -7,6 +7,10 @@
 databricks-sdk>=0.118.0
 fastapi>=0.115.12
 uvicorn>=0.34.2
-fastmcp>=2.12.5
-mcp[cli]>=1.14.0
+# fastmcp/mcp are MAJOR-version-pinned: 2.x and 3.x have incompatible APIs (e.g.
+# FastMCP.get_tools() was removed in 3.x), so an unbounded floor would make installs
+# non-deterministic across the 2.x->3.x boundary. We target 3.x (validated end-to-end:
+# http_app(path=..., stateless_http=True) -> StarletteWithLifespan mount + @tool).
+fastmcp>=3.4,<4
+mcp[cli]>=1.14.0,<2
 pydantic>=2

--- a/genie-code/mcp-genie-space-history/app/requirements.txt
+++ b/genie-code/mcp-genie-space-history/app/requirements.txt
@@ -1,0 +1,12 @@
+# Runtime dependencies for the Genie Space History MCP server (Databricks Apps
+# installs this on deploy). Pins per spec §10 / P0 findings.
+#
+# databricks-sdk>=0.118.0: floor for the genie `etag` field used by Genie Code's
+# rollback apply path (P0 finding F-1). The MCP itself only uses the SDK's
+# statement_execution + current_user APIs, but we keep the same floor.
+databricks-sdk>=0.118.0
+fastapi>=0.115.12
+uvicorn>=0.34.2
+fastmcp>=2.12.5
+mcp[cli]>=1.14.0
+pydantic>=2

--- a/genie-code/mcp-genie-space-history/app/server/__init__.py
+++ b/genie-code/mcp-genie-space-history/app/server/__init__.py
@@ -1,0 +1,19 @@
+"""Genie Space History MCP server (P1 — write + read).
+
+Productionizes the P0 spike (../spike/) into a real package: a FastAPI + FastMCP
+server, mounted at ``/mcp`` over stateless streamable HTTP, that persists the
+artifacts the ``genie-code/`` skills emit to governed Unity Catalog Delta tables.
+
+Module map:
+  * ``config``       — env-driven :class:`Settings` (spec §10).
+  * ``errors``       — structured tool errors (scope_error / validation).
+  * ``sql``          — ``exec_sql`` + identifier quoting + the param/result adapter (spec §11).
+  * ``schema``       — DDL for the 7 UC tables + the ``only_mine`` row-filter function (spec §7.1).
+  * ``auth``         — OBO (per-request user) vs app-SP WorkspaceClient builders (spec §5).
+  * ``provisioning`` — idempotent bootstrap: schema/tables/filter/ownership/grants (§7.1/§10).
+  * ``store``        — :class:`UCTableStore`, the UC storage adapter (spec §6/§7).
+  * ``tools``        — the four P1 MCP tools (spec §6).
+  * ``app``/``main`` — the FastAPI/FastMCP wiring + uvicorn entrypoint (spec §3/§10).
+"""
+
+__version__ = "0.1.0"

--- a/genie-code/mcp-genie-space-history/app/server/app.py
+++ b/genie-code/mcp-genie-space-history/app/server/app.py
@@ -1,0 +1,104 @@
+"""FastAPI + FastMCP application (spec §3 / §10).
+
+* ``mcp_server.http_app(path="/mcp", stateless_http=True)`` → the MCP server
+  mounted at ``/mcp`` over stateless streamable HTTP (Genie Code requirement).
+* A middleware captures ``X-Forwarded-Access-Token`` into a ContextVar for OBO;
+  it is reset after each request so it never leaks across requests.
+* CORS is allow-listed to the workspace origin(s) from ``CORS_ALLOW_ORIGINS``.
+* On startup the app SP runs the idempotent bootstrap (schema/tables/filter/
+  ownership/grants); failures are logged but never crash startup (spec §7.1).
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import asynccontextmanager
+
+from fastapi import FastAPI, Request
+from fastapi.middleware.cors import CORSMiddleware
+from fastmcp import FastMCP
+
+from . import auth, provisioning
+from .config import Settings
+from .tools import register_tools
+
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger("mcp-genie-space-history")
+
+settings = Settings.from_env()
+
+mcp_server = FastMCP(name="mcp-genie-space-history")
+register_tools(mcp_server, settings)
+
+# stateless_http=True: each request is self-contained (no mcp-session-id handshake),
+# which Genie Code / horizontally-scaled Apps require. path="/mcp" is the contract.
+mcp_app = mcp_server.http_app(path="/mcp", stateless_http=True)
+
+
+def _run_startup_bootstrap() -> None:
+    """Provision UC objects as the app SP (best-effort; never raises)."""
+    missing = settings.missing_required()
+    if missing:
+        logger.warning("bootstrap skipped: missing required env: %s", ", ".join(missing))
+        return
+    try:
+        report = provisioning.bootstrap(auth.get_app_workspace_client(), settings)
+        logger.info("bootstrap report: %s", report)
+        if report.get("warnings"):
+            logger.warning("bootstrap warnings: %s", report["warnings"])
+    except Exception as exc:  # noqa: BLE001 — startup must survive bootstrap failures
+        logger.exception("bootstrap failed (continuing startup): %s", exc)
+
+
+@asynccontextmanager
+async def lifespan(app: FastAPI):
+    # Run provisioning only inside a deployed App (where the SP exists) unless an
+    # operator explicitly opts in; preserve FastMCP's own session-manager lifespan.
+    if auth.running_in_app():
+        _run_startup_bootstrap()
+    else:
+        logger.info("not running in a Databricks App; skipping startup bootstrap")
+    async with mcp_app.lifespan(app):
+        yield
+
+
+api = FastAPI(title="mcp-genie-space-history", version="0.1.0")
+
+
+@api.get("/", include_in_schema=False)
+async def root() -> dict:
+    return {"message": "Genie Space History MCP running", "mcp_endpoint": "/mcp"}
+
+
+@api.get("/healthz", include_in_schema=False)
+async def healthz() -> dict:
+    return {"status": "healthy", "config": settings.as_public_dict()}
+
+
+# Combine the MCP protocol routes with the custom API routes under one app.
+app = FastAPI(
+    title="Genie Space History MCP",
+    version="0.1.0",
+    routes=[*mcp_app.routes, *api.routes],
+    lifespan=lifespan,
+)
+
+# CORS: allow only the configured workspace origin(s) (spec §3/§10). When unset,
+# no cross-origin browser access is permitted (fail-closed).
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=list(settings.cors_allow_origins),
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+@app.middleware("http")
+async def capture_obo_token(request: Request, call_next):
+    """Stash only the OBO token for this request; reset it afterward so it never leaks."""
+    reset = auth.obo_token_var.set(request.headers.get(auth.OBO_HEADER))
+    try:
+        return await call_next(request)
+    finally:
+        auth.obo_token_var.reset(reset)

--- a/genie-code/mcp-genie-space-history/app/server/app.py
+++ b/genie-code/mcp-genie-space-history/app/server/app.py
@@ -46,6 +46,14 @@ def _run_startup_bootstrap() -> None:
         logger.info("bootstrap report: %s", report)
         if report.get("warnings"):
             logger.warning("bootstrap warnings: %s", report["warnings"])
+        if not report.get("ok"):
+            # Row isolation / table creation incomplete — grantee access may be withheld.
+            logger.error(
+                "bootstrap NOT ok: errors=%s grants_withheld=%s — row isolation incomplete; "
+                "an operator must resolve before relying on per-user history",
+                report.get("errors"),
+                report.get("grants_withheld"),
+            )
     except Exception as exc:  # noqa: BLE001 — startup must survive bootstrap failures
         logger.exception("bootstrap failed (continuing startup): %s", exc)
 

--- a/genie-code/mcp-genie-space-history/app/server/auth.py
+++ b/genie-code/mcp-genie-space-history/app/server/auth.py
@@ -1,0 +1,69 @@
+"""Identity & auth — OBO (per-request user) vs the app service principal (spec §5).
+
+  * **OBO** — every artifact read/write runs as the *calling user*. We build a
+    fresh ``WorkspaceClient`` from the ``X-Forwarded-Access-Token`` header on each
+    request and NEVER cache it. UC row filters then isolate per user.
+  * **App SP** — used ONLY for bootstrap/admin (schema + table provisioning).
+    Never the write actor for user artifacts; we never silently fall back to it
+    for a user write (spec §5).
+
+The middleware in ``app.py`` stashes the OBO token in a ``ContextVar``; tools read
+it here. On a missing token / disabled OBO, :func:`get_user_workspace_client`
+raises :class:`OBOScopeError` so the tool can return a structured ``scope_error``.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import os
+
+from databricks.sdk import WorkspaceClient
+
+from .errors import OBOScopeError
+
+OBO_HEADER = "x-forwarded-access-token"
+
+# Populated per-request by the middleware in app.py (only the OBO token, nothing else).
+obo_token_var: contextvars.ContextVar = contextvars.ContextVar("obo_token", default=None)
+
+
+def running_in_app() -> bool:
+    """True when executing inside a deployed Databricks App (SP + OBO are available)."""
+    return "DATABRICKS_APP_NAME" in os.environ
+
+
+def get_app_workspace_client() -> WorkspaceClient:
+    """App service-principal client (auto-injected ``DATABRICKS_CLIENT_ID``/``SECRET``).
+
+    Bootstrap/admin only — schema + table provisioning, ownership, grants (spec §5).
+    Locally this falls back to the developer's default credentials.
+    """
+    return WorkspaceClient()
+
+
+def get_user_workspace_client(*, obo_enabled: bool = True) -> WorkspaceClient:
+    """On-Behalf-Of-User client built from the forwarded user token (spec §5).
+
+    Raises :class:`OBOScopeError` when the token is absent or OBO is disabled —
+    the tool turns that into a ``scope_error`` for the user; it does NOT fall back
+    to the app SP for a user-scoped write.
+
+    Outside a deployed App (local dev / tests), returns the developer identity so
+    the same code path is exercisable without the forwarded header.
+    """
+    if not running_in_app():
+        return WorkspaceClient()
+
+    if not obo_enabled:
+        raise OBOScopeError(
+            "On-Behalf-Of-User auth is disabled for this server (OBO_ENABLED=false). "
+            "User-scoped reads/writes require OBO.",
+        )
+
+    token = obo_token_var.get()
+    if not token:
+        raise OBOScopeError(
+            f"OBO token missing: no '{OBO_HEADER}' header on the request. Confirm OBO is "
+            "enabled in the Previews portal and the app declares `user_api_scopes: sql`.",
+        )
+    return WorkspaceClient(token=token, auth_type="pat")

--- a/genie-code/mcp-genie-space-history/app/server/config.py
+++ b/genie-code/mcp-genie-space-history/app/server/config.py
@@ -1,0 +1,89 @@
+"""Env-driven configuration (spec §10).
+
+All deployment knobs come from environment variables set in ``app.yaml``:
+
+  * ``HISTORY_CATALOG``     — a **pre-existing** UC catalog. The app NEVER creates it.
+  * ``HISTORY_OWNER_GROUP`` — durable account group that OWNS the schema/tables
+                              (survives app/SP deletion — spec §7.1).
+  * ``HISTORY_GRANTEE``     — user group granted SELECT/MODIFY for OBO reads/writes.
+  * ``SQL_WAREHOUSE_ID``    — warehouse all UC SQL runs on.
+  * ``CORS_ALLOW_ORIGINS``  — comma-separated workspace origin allowlist (spec §3).
+  * ``HISTORY_USE_VARIANT`` — opt-in VARIANT JSON columns (default STRING — spec §7.1/§12 #3).
+  * ``OBO_ENABLED``         — OBO feature flag for graceful degradation (spec §5/§12 #2).
+
+The schema name is fixed at ``genie_space_history`` (spec §7.1).
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from typing import Mapping, Optional
+
+# Fixed by the design spec §7.1 — never configurable.
+HISTORY_SCHEMA = "genie_space_history"
+
+
+def _as_bool(value: Optional[str], *, default: bool) -> bool:
+    if value is None:
+        return default
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+@dataclass(frozen=True)
+class Settings:
+    """Resolved, immutable server configuration."""
+
+    history_catalog: str
+    history_owner_group: str
+    history_grantee: str
+    sql_warehouse_id: str
+    history_schema: str = HISTORY_SCHEMA
+    cors_allow_origins: tuple[str, ...] = field(default_factory=tuple)
+    use_variant: bool = False
+    obo_enabled: bool = True
+
+    @property
+    def fq_schema(self) -> str:
+        """``catalog.schema`` for logging/display (NOT pre-quoted)."""
+        return f"{self.history_catalog}.{self.history_schema}"
+
+    @classmethod
+    def from_env(cls, env: Optional[Mapping[str, str]] = None) -> "Settings":
+        """Build settings from the process environment (or an injected mapping for tests)."""
+        env = env if env is not None else os.environ
+        origins = tuple(
+            o.strip() for o in env.get("CORS_ALLOW_ORIGINS", "").split(",") if o.strip()
+        )
+        return cls(
+            history_catalog=env.get("HISTORY_CATALOG", "").strip(),
+            history_owner_group=env.get("HISTORY_OWNER_GROUP", "").strip(),
+            history_grantee=env.get("HISTORY_GRANTEE", "").strip(),
+            sql_warehouse_id=env.get("SQL_WAREHOUSE_ID", "").strip(),
+            cors_allow_origins=origins,
+            use_variant=_as_bool(env.get("HISTORY_USE_VARIANT"), default=False),
+            obo_enabled=_as_bool(env.get("OBO_ENABLED"), default=True),
+        )
+
+    def missing_required(self) -> list[str]:
+        """Names of required env vars that are unset (for a fail-fast startup check)."""
+        required = {
+            "HISTORY_CATALOG": self.history_catalog,
+            "HISTORY_OWNER_GROUP": self.history_owner_group,
+            "HISTORY_GRANTEE": self.history_grantee,
+            "SQL_WAREHOUSE_ID": self.sql_warehouse_id,
+        }
+        return [name for name, value in required.items() if not value]
+
+    def as_public_dict(self) -> dict[str, object]:
+        """Non-secret config echo for ``/healthz`` / structured logs."""
+        return {
+            "history_catalog": self.history_catalog,
+            "history_schema": self.history_schema,
+            "history_owner_group": self.history_owner_group,
+            "history_grantee": self.history_grantee,
+            "sql_warehouse_id": self.sql_warehouse_id,
+            "cors_allow_origins": list(self.cors_allow_origins),
+            "use_variant": self.use_variant,
+            "obo_enabled": self.obo_enabled,
+        }

--- a/genie-code/mcp-genie-space-history/app/server/errors.py
+++ b/genie-code/mcp-genie-space-history/app/server/errors.py
@@ -13,11 +13,21 @@ actionable, machine-readable result. The two shapes that matter most:
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 
 class ToolValidationError(ValueError):
     """An input failed validation against the §7 field contracts."""
+
+
+class StorageContentionError(RuntimeError):
+    """A write could not converge under concurrency (e.g. version allocation).
+
+    UC SQL warehouses enforce no PK/unique constraints or row locks, so writes use
+    a bounded optimistic-retry (see :mod:`server.store`). When that retry budget is
+    exhausted the tool surfaces this as a clean ``contention`` error rather than
+    leaving a duplicate/colliding row.
+    """
 
 
 class OBOScopeError(RuntimeError):
@@ -66,28 +76,27 @@ _SCOPE_MARKERS = (
     "invalid access token",
     "missing scope",
     "unauthorized",
+    "unauthenticated",
     "401",
 )
+
+# SDK exception class names that are unambiguously token/identity-auth failures
+# (401-class). ``PermissionDenied`` (403, a UC grant issue) is deliberately EXCLUDED
+# so it is never relabeled a scope error.
+_SCOPE_EXCEPTION_NAMES = ("Unauthenticated",)
 
 
 def looks_like_scope_error(exc: Exception) -> bool:
     """Heuristic: does this SQL/auth failure look like a missing OAuth scope?
 
     The definitive scope signal is the absent OBO token (handled in ``auth`` via
-    :class:`OBOScopeError`). This only catches the token-level authorization
+    :class:`OBOScopeError`). This also catches the token-level authorization
     failures a deployed app hits when its OBO token defaults to identity-only
-    scopes (spec §5, P0 finding F-6).
+    scopes (spec §5, P0 finding F-6) — including the SDK ``Unauthenticated`` (401)
+    raised while resolving the caller's identity. ``PermissionDenied`` (403, a UC
+    grant denial) is intentionally NOT treated as a scope error.
     """
+    if type(exc).__name__ in _SCOPE_EXCEPTION_NAMES:
+        return True
     msg = str(exc).lower()
     return any(marker in msg for marker in _SCOPE_MARKERS)
-
-
-def exception_to_payload(
-    exc: Exception, *, default_type: str = "error"
-) -> Optional[dict[str, Any]]:
-    """Map a known exception type to a structured payload, or ``None`` if unknown."""
-    if isinstance(exc, OBOScopeError):
-        return scope_error_payload(str(exc), required_scope=exc.required_scope)
-    if isinstance(exc, ToolValidationError):
-        return validation_error_payload(str(exc))
-    return None

--- a/genie-code/mcp-genie-space-history/app/server/errors.py
+++ b/genie-code/mcp-genie-space-history/app/server/errors.py
@@ -1,0 +1,93 @@
+"""Structured errors surfaced by the MCP tools.
+
+The tools never raise raw exceptions back over MCP — they translate them into
+plain JSON-serializable dicts so the calling agent (Genie Code) gets an
+actionable, machine-readable result. The two shapes that matter most:
+
+  * ``scope_error`` — the forwarded OBO token is missing or lacks the ``sql``
+    scope (spec §5). The server NEVER silently falls back to the app SP for a
+    user write; it returns this so the user enables the scope.
+  * ``validation_error`` — the inputs violated a §7 field contract (e.g. an
+    unknown ``artifact_type``, or a missing required field).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+class ToolValidationError(ValueError):
+    """An input failed validation against the §7 field contracts."""
+
+
+class OBOScopeError(RuntimeError):
+    """The OBO token is absent / OBO is disabled / a required scope is missing.
+
+    Carries the scope the user must enable so the tool can render an actionable
+    ``scope_error`` payload (spec §5).
+    """
+
+    def __init__(self, message: str, *, required_scope: str = "sql"):
+        super().__init__(message)
+        self.required_scope = required_scope
+
+
+def scope_error_payload(message: str, *, required_scope: str = "sql") -> dict[str, Any]:
+    """Build the structured ``scope_error`` result returned by a tool (spec §5)."""
+    return {
+        "ok": False,
+        "error_type": "scope_error",
+        "required_scope": required_scope,
+        "message": message,
+        "remediation": (
+            f"Enable On-Behalf-Of-User auth in the Previews portal and ensure the app's "
+            f"`user_api_scopes` includes `{required_scope}`, then reconnect the MCP server."
+        ),
+    }
+
+
+def validation_error_payload(message: str) -> dict[str, Any]:
+    """Build the structured ``validation_error`` result returned by a tool."""
+    return {"ok": False, "error_type": "validation_error", "message": message}
+
+
+def error_payload(error_type: str, message: str) -> dict[str, Any]:
+    """Build a generic structured error result."""
+    return {"ok": False, "error_type": error_type, "message": message}
+
+
+# Lower-cased substrings that mark an OAuth-scope / token-authorization failure
+# (as opposed to an ordinary UC grant denial). Kept conservative so a plain
+# "user does not have SELECT on table" grant issue is NOT mislabeled a scope error.
+_SCOPE_MARKERS = (
+    "insufficient_scope",
+    "insufficient scope",
+    "invalid_token",
+    "invalid access token",
+    "missing scope",
+    "unauthorized",
+    "401",
+)
+
+
+def looks_like_scope_error(exc: Exception) -> bool:
+    """Heuristic: does this SQL/auth failure look like a missing OAuth scope?
+
+    The definitive scope signal is the absent OBO token (handled in ``auth`` via
+    :class:`OBOScopeError`). This only catches the token-level authorization
+    failures a deployed app hits when its OBO token defaults to identity-only
+    scopes (spec §5, P0 finding F-6).
+    """
+    msg = str(exc).lower()
+    return any(marker in msg for marker in _SCOPE_MARKERS)
+
+
+def exception_to_payload(
+    exc: Exception, *, default_type: str = "error"
+) -> Optional[dict[str, Any]]:
+    """Map a known exception type to a structured payload, or ``None`` if unknown."""
+    if isinstance(exc, OBOScopeError):
+        return scope_error_payload(str(exc), required_scope=exc.required_scope)
+    if isinstance(exc, ToolValidationError):
+        return validation_error_payload(str(exc))
+    return None

--- a/genie-code/mcp-genie-space-history/app/server/errors.py
+++ b/genie-code/mcp-genie-space-history/app/server/errors.py
@@ -20,16 +20,6 @@ class ToolValidationError(ValueError):
     """An input failed validation against the §7 field contracts."""
 
 
-class StorageContentionError(RuntimeError):
-    """A write could not converge under concurrency (e.g. version allocation).
-
-    UC SQL warehouses enforce no PK/unique constraints or row locks, so writes use
-    a bounded optimistic-retry (see :mod:`server.store`). When that retry budget is
-    exhausted the tool surfaces this as a clean ``contention`` error rather than
-    leaving a duplicate/colliding row.
-    """
-
-
 class OBOScopeError(RuntimeError):
     """The OBO token is absent / OBO is disabled / a required scope is missing.
 

--- a/genie-code/mcp-genie-space-history/app/server/main.py
+++ b/genie-code/mcp-genie-space-history/app/server/main.py
@@ -1,0 +1,16 @@
+"""uvicorn entry point. Binds to ``DATABRICKS_APP_PORT`` (default 8000) — spec §10."""
+
+from __future__ import annotations
+
+import os
+
+import uvicorn
+
+
+def main() -> None:
+    port = int(os.environ.get("DATABRICKS_APP_PORT", "8000"))
+    uvicorn.run("server.app:app", host="0.0.0.0", port=port)
+
+
+if __name__ == "__main__":
+    main()

--- a/genie-code/mcp-genie-space-history/app/server/provisioning.py
+++ b/genie-code/mcp-genie-space-history/app/server/provisioning.py
@@ -8,10 +8,15 @@ OBO ``HISTORY_GRANTEE`` (while keeping the SP's own SELECT/MODIFY).
 Hard invariants (spec §7.1/§10):
   * The **catalog is NEVER created** — it must pre-exist; we only ``USE`` it.
   * Bootstrap is **fully idempotent** (``IF NOT EXISTS`` + existence checks).
-  * Ownership reassignment **may legitimately fail** if the SP isn't a member of
-    ``HISTORY_OWNER_GROUP`` (UC anti-escalation). That is captured as a structured
-    WARNING and bootstrap continues — startup must NOT crash (an operator/metastore
-    admin runs the one-time ``OWNER TO``).
+  * **Row isolation is REQUIRED, not best-effort (spec §5).** The ``only_mine``
+    function and the per-table row filter must succeed, and ``HISTORY_GRANTEE`` is
+    granted ``SELECT``/``MODIFY`` **per table, only on tables whose row filter
+    actually applied** — never schema-wide. If the function or any table's filter
+    fails, that table's grant is **withheld** and ``report["ok"]`` is ``False``, so
+    the grantee can never reach an unfiltered table.
+  * **Only** ownership reassignment may warn-and-continue: it legitimately fails if
+    the SP isn't a member of ``HISTORY_OWNER_GROUP`` (UC anti-escalation), and an
+    operator/metastore admin runs the one-time ``OWNER TO``. Startup never crashes.
 
 The report this returns is logged at startup; nothing here raises.
 """
@@ -59,26 +64,40 @@ class _Report:
             "catalog_created": False,  # invariant: we never CREATE CATALOG
             "tables_created": [],
             "tables_existing": [],
+            "row_filtered": [],
+            "grants_withheld": [],  # tables denied grantee access because the filter didn't apply
             "steps": [],
             "warnings": [],
+            "errors": [],
         }
 
     def step(self, name: str, status: str, **extra: Any) -> None:
         entry = {"step": name, "status": status, **extra}
         self.data["steps"].append(entry)
 
-    def warn(self, name: str, exc: Exception) -> None:
+    def warn(self, name: str, exc: object) -> None:
         self.step(name, "warning", error=str(exc))
         self.data["warnings"].append(f"{name}: {exc}")
 
-    def attempt(self, name: str, fn: Callable[[], Any]) -> bool:
-        """Run ``fn``; on failure record a WARNING and continue (never raise)."""
+    def error(self, name: str, exc: object) -> None:
+        self.step(name, "error", error=str(exc))
+        self.data["errors"].append(f"{name}: {exc}")
+
+    def attempt(self, name: str, fn: Callable[[], Any], *, required: bool = False) -> bool:
+        """Run ``fn``; on failure record it and continue (never raise).
+
+        ``required=True`` records a structured ERROR (gates ``report["ok"]``);
+        otherwise a WARNING (warn-and-continue — only ownership transfer uses this).
+        """
         try:
             fn()
             self.step(name, "ok")
             return True
         except Exception as exc:  # noqa: BLE001 — bootstrap must never crash startup
-            self.warn(name, exc)
+            if required:
+                self.error(name, exc)
+            else:
+                self.warn(name, exc)
             return False
 
 
@@ -91,8 +110,7 @@ def bootstrap(w: WorkspaceClient, settings: Settings) -> dict:
 
     missing = settings.missing_required()
     if missing:
-        report.data["ok"] = False
-        report.warn("config", RuntimeError(f"missing required env: {', '.join(missing)}"))
+        report.error("config", RuntimeError(f"missing required env: {', '.join(missing)}"))
         return report.data
 
     # 1) Catalog must pre-exist and be accessible — we NEVER create it.
@@ -100,8 +118,7 @@ def bootstrap(w: WorkspaceClient, settings: Settings) -> dict:
         _run(w, wh, f"SHOW SCHEMAS IN {cat}")
         report.step("catalog_accessible", "ok")
     except SqlError as exc:
-        report.data["ok"] = False
-        report.warn("catalog_accessible", exc)
+        report.error("catalog_accessible", exc)
         report.data["note"] = (
             "Catalog missing or the app SP lacks USE CATALOG. The operator must grant the "
             "app SP `USE CATALOG` + `CREATE SCHEMA` on HISTORY_CATALOG (spec §10). "
@@ -109,51 +126,86 @@ def bootstrap(w: WorkspaceClient, settings: Settings) -> dict:
         )
         return report.data
 
-    # 2) Schema (idempotent).
-    report.attempt("create_schema", lambda: _run(w, wh, f"CREATE SCHEMA IF NOT EXISTS {fq}"))
-
-    # 3) Row-filter function (idempotent).
-    report.attempt(
-        "create_only_mine_function",
-        lambda: _run(w, wh, schema.only_mine_function_ddl(fq)),
+    # 2) Schema (idempotent, required).
+    schema_ok = report.attempt(
+        "create_schema", lambda: _run(w, wh, f"CREATE SCHEMA IF NOT EXISTS {fq}"), required=True
     )
 
-    # 4) The seven tables (idempotent). Track created-vs-existing for the report.
+    # 3) Row-filter function (idempotent, REQUIRED — it gates row isolation, spec §5).
+    function_ok = report.attempt(
+        "create_only_mine_function",
+        lambda: _run(w, wh, schema.only_mine_function_ddl(fq)),
+        required=True,
+    )
+
+    # 4) The seven tables (idempotent, required). Track created-vs-existing.
+    tables_present: set[str] = set()
     for table_name, ddl in schema.all_table_ddls(fq, use_variant=settings.use_variant):
         try:
             existed = bool(_rows(_run(w, wh, f"SHOW TABLES IN {fq} LIKE '{table_name}'")))
         except SqlError:
             existed = False
-        ok = report.attempt(f"create_table:{table_name}", lambda d=ddl: _run(w, wh, d))
+        ok = report.attempt(
+            f"create_table:{table_name}", lambda d=ddl: _run(w, wh, d), required=True
+        )
         if ok:
+            tables_present.add(table_name)
             (report.data["tables_existing"] if existed else report.data["tables_created"]).append(
                 table_name
             )
 
-    # 5) Row filter on created_by for every table (idempotent — SET replaces).
-    #    May fail on a restart once ownership has moved off the SP → captured as WARNING.
+    # 5) Row filter on created_by for every present table (REQUIRED — spec §5). A table
+    #    only counts as "protected" once its filter actually applied; without the function
+    #    no filter can apply, so every grant is withheld below.
+    row_filtered: set[str] = set()
     for table_name in schema.ALL_TABLE_NAMES:
+        if table_name not in tables_present:
+            continue
+        if not function_ok:
+            report.error(f"row_filter:{table_name}", "only_mine function unavailable")
+            continue
         stmt = (
             f"ALTER TABLE {fq}.{quote_ident(table_name)} "
             f"SET ROW FILTER {fq}.{quote_ident(schema.ROW_FILTER_FUNCTION)} ON (created_by)"
         )
-        report.attempt(f"row_filter:{table_name}", lambda s=stmt: _run(w, wh, s))
+        if report.attempt(f"row_filter:{table_name}", lambda s=stmt: _run(w, wh, s), required=True):
+            row_filtered.add(table_name)
 
-    # 6) Grants for the OBO user group (HISTORY_GRANTEE). Done BEFORE the ownership
-    #    handoff (while the SP still owns the objects), so the grants reliably apply
-    #    and persist past the OWNER TO. USE CATALOG may warn if the SP can't grant at
-    #    the catalog level — that grant is ultimately the operator's responsibility.
+    protected = {t for t in schema.ALL_TABLE_NAMES if t in tables_present and t in row_filtered}
+
+    # 6) Grants for the OBO user group (HISTORY_GRANTEE), done BEFORE the ownership handoff
+    #    (while the SP still owns the objects). USE CATALOG / USE SCHEMA are traversal-only
+    #    (no data access) — best-effort. SELECT/MODIFY are granted PER TABLE and ONLY on
+    #    row-filtered tables: a table whose filter didn't apply has its grant WITHHELD so
+    #    the grantee can never read unfiltered rows (spec §5).
     grantee = _quote_principal(settings.history_grantee)
     report.attempt(
         "grant_use_catalog:grantee",
         lambda: _run(w, wh, f"GRANT USE CATALOG ON CATALOG {cat} TO {grantee}"),
     )
     report.attempt(
-        "grant_schema:grantee",
-        lambda: _run(w, wh, f"GRANT USE SCHEMA, SELECT, MODIFY ON SCHEMA {fq} TO {grantee}"),
+        "grant_use_schema:grantee",
+        lambda: _run(w, wh, f"GRANT USE SCHEMA ON SCHEMA {fq} TO {grantee}"),
     )
+    for table_name in schema.ALL_TABLE_NAMES:
+        tbl = f"{fq}.{quote_ident(table_name)}"
+        if table_name in protected:
+            # Granting a protected table is operational (warn): failure just means the
+            # grantee lacks access — it never EXPOSES unfiltered rows.
+            report.attempt(
+                f"grant_table:grantee:{table_name}",
+                lambda t=tbl: _run(w, wh, f"GRANT SELECT, MODIFY ON TABLE {t} TO {grantee}"),
+            )
+        elif table_name in tables_present:
+            report.error(
+                f"grant_withheld:grantee:{table_name}",
+                "row filter not applied; withholding SELECT/MODIFY to keep rows isolated",
+            )
+            report.data["grants_withheld"].append(table_name)
 
     # 7) Ensure the app SP keeps SELECT/MODIFY after it stops being owner (spec §7.1).
+    #    The SP is the trusted bootstrapper, not the OBO isolation concern — grant it on
+    #    every present table. Operational, so warn-and-continue.
     try:
         sp_name = w.current_user.me().user_name
     except Exception as exc:  # noqa: BLE001
@@ -162,19 +214,22 @@ def bootstrap(w: WorkspaceClient, settings: Settings) -> dict:
     if sp_name:
         sp = _quote_principal(sp_name)
         report.attempt(
-            "grant_schema:app_sp",
-            lambda: _run(w, wh, f"GRANT USE SCHEMA, SELECT, MODIFY ON SCHEMA {fq} TO {sp}"),
+            "grant_use_schema:app_sp",
+            lambda: _run(w, wh, f"GRANT USE SCHEMA ON SCHEMA {fq} TO {sp}"),
         )
+        for table_name in sorted(tables_present):
+            tbl = f"{fq}.{quote_ident(table_name)}"
+            report.attempt(
+                f"grant_table:app_sp:{table_name}",
+                lambda t=tbl: _run(w, wh, f"GRANT SELECT, MODIFY ON TABLE {t} TO {sp}"),
+            )
 
     # 8) Durable ownership handoff to HISTORY_OWNER_GROUP (schema + each table; the
     #    function transfer is admin-gated). Ownership does NOT inherit — do each one.
-    #    Failure here is EXPECTED when the SP isn't a member of the group → WARNING,
-    #    and an operator/metastore admin runs the one-time OWNER TO (spec §7.1/§10).
+    #    This is the ONLY step allowed to warn-and-continue: it is EXPECTED to fail when
+    #    the SP isn't a member of the group, and an admin runs the one-time OWNER TO.
     owner = _quote_principal(settings.history_owner_group)
-    report.attempt(
-        "owner_to:schema",
-        lambda: _run(w, wh, f"ALTER SCHEMA {fq} OWNER TO {owner}"),
-    )
+    report.attempt("owner_to:schema", lambda: _run(w, wh, f"ALTER SCHEMA {fq} OWNER TO {owner}"))
     for table_name in schema.ALL_TABLE_NAMES:
         stmt = f"ALTER TABLE {fq}.{quote_ident(table_name)} OWNER TO {owner}"
         report.attempt(f"owner_to:{table_name}", lambda s=stmt: _run(w, wh, s))
@@ -187,7 +242,13 @@ def bootstrap(w: WorkspaceClient, settings: Settings) -> dict:
         ),
     )
 
-    # Bootstrap "succeeded" if the data path is usable: schema + all tables exist.
-    created_or_existing = set(report.data["tables_created"]) | set(report.data["tables_existing"])
-    report.data["ok"] = set(schema.ALL_TABLE_NAMES).issubset(created_or_existing)
+    # Bootstrap "succeeded" only if the full row-isolation model is in place: schema +
+    # function + all 7 tables created AND all 7 row-filtered (spec §5).
+    report.data["row_filtered"] = sorted(row_filtered)
+    report.data["ok"] = (
+        schema_ok
+        and function_ok
+        and set(schema.ALL_TABLE_NAMES) <= tables_present
+        and set(schema.ALL_TABLE_NAMES) <= row_filtered
+    )
     return report.data

--- a/genie-code/mcp-genie-space-history/app/server/provisioning.py
+++ b/genie-code/mcp-genie-space-history/app/server/provisioning.py
@@ -1,0 +1,193 @@
+"""Startup bootstrap, run as the app service principal (spec §7.1 / §10).
+
+Idempotently creates the ``genie_space_history`` schema and ALL SEVEN per-artifact
+tables, the ``only_mine`` row-filter function, applies the row filter to every
+table, reassigns ownership to the durable ``HISTORY_OWNER_GROUP``, and grants the
+OBO ``HISTORY_GRANTEE`` (while keeping the SP's own SELECT/MODIFY).
+
+Hard invariants (spec §7.1/§10):
+  * The **catalog is NEVER created** — it must pre-exist; we only ``USE`` it.
+  * Bootstrap is **fully idempotent** (``IF NOT EXISTS`` + existence checks).
+  * Ownership reassignment **may legitimately fail** if the SP isn't a member of
+    ``HISTORY_OWNER_GROUP`` (UC anti-escalation). That is captured as a structured
+    WARNING and bootstrap continues — startup must NOT crash (an operator/metastore
+    admin runs the one-time ``OWNER TO``).
+
+The report this returns is logged at startup; nothing here raises.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from databricks.sdk import WorkspaceClient
+
+from . import schema
+from .config import Settings
+from .sql import SqlError, exec_sql, quote_ident
+
+
+def _quote_principal(name: str) -> str:
+    """Backtick-quote a UC principal/group name (groups/SP-ids allow ``-``/spaces).
+
+    Escapes embedded backticks. Names come from operator-set env, not user input.
+    """
+    return "`" + name.replace("`", "``") + "`"
+
+
+def _run(w: WorkspaceClient, warehouse_id: str, sql: str):
+    # All provisioning statements bind no user data — identifiers come from our own
+    # schema constants / operator env, validated + quoted above.
+    return exec_sql(w, warehouse_id, sql)
+
+
+def _rows(resp) -> list:
+    if resp is not None and resp.result and resp.result.data_array:
+        return resp.result.data_array
+    return []
+
+
+class _Report:
+    def __init__(self, settings: Settings) -> None:
+        self.data: dict[str, Any] = {
+            "ok": False,
+            "catalog": settings.history_catalog,
+            "schema": settings.fq_schema,
+            "owner_group": settings.history_owner_group,
+            "grantee": settings.history_grantee,
+            "use_variant": settings.use_variant,
+            "catalog_created": False,  # invariant: we never CREATE CATALOG
+            "tables_created": [],
+            "tables_existing": [],
+            "steps": [],
+            "warnings": [],
+        }
+
+    def step(self, name: str, status: str, **extra: Any) -> None:
+        entry = {"step": name, "status": status, **extra}
+        self.data["steps"].append(entry)
+
+    def warn(self, name: str, exc: Exception) -> None:
+        self.step(name, "warning", error=str(exc))
+        self.data["warnings"].append(f"{name}: {exc}")
+
+    def attempt(self, name: str, fn: Callable[[], Any]) -> bool:
+        """Run ``fn``; on failure record a WARNING and continue (never raise)."""
+        try:
+            fn()
+            self.step(name, "ok")
+            return True
+        except Exception as exc:  # noqa: BLE001 — bootstrap must never crash startup
+            self.warn(name, exc)
+            return False
+
+
+def bootstrap(w: WorkspaceClient, settings: Settings) -> dict:
+    """Provision schema/tables/filter/ownership/grants idempotently. Never raises."""
+    report = _Report(settings)
+    cat = quote_ident(settings.history_catalog)
+    fq = f"{quote_ident(settings.history_catalog)}.{quote_ident(settings.history_schema)}"
+    wh = settings.sql_warehouse_id
+
+    missing = settings.missing_required()
+    if missing:
+        report.data["ok"] = False
+        report.warn("config", RuntimeError(f"missing required env: {', '.join(missing)}"))
+        return report.data
+
+    # 1) Catalog must pre-exist and be accessible — we NEVER create it.
+    try:
+        _run(w, wh, f"SHOW SCHEMAS IN {cat}")
+        report.step("catalog_accessible", "ok")
+    except SqlError as exc:
+        report.data["ok"] = False
+        report.warn("catalog_accessible", exc)
+        report.data["note"] = (
+            "Catalog missing or the app SP lacks USE CATALOG. The operator must grant the "
+            "app SP `USE CATALOG` + `CREATE SCHEMA` on HISTORY_CATALOG (spec §10). "
+            "The app never creates the catalog."
+        )
+        return report.data
+
+    # 2) Schema (idempotent).
+    report.attempt("create_schema", lambda: _run(w, wh, f"CREATE SCHEMA IF NOT EXISTS {fq}"))
+
+    # 3) Row-filter function (idempotent).
+    report.attempt(
+        "create_only_mine_function",
+        lambda: _run(w, wh, schema.only_mine_function_ddl(fq)),
+    )
+
+    # 4) The seven tables (idempotent). Track created-vs-existing for the report.
+    for table_name, ddl in schema.all_table_ddls(fq, use_variant=settings.use_variant):
+        try:
+            existed = bool(_rows(_run(w, wh, f"SHOW TABLES IN {fq} LIKE '{table_name}'")))
+        except SqlError:
+            existed = False
+        ok = report.attempt(f"create_table:{table_name}", lambda d=ddl: _run(w, wh, d))
+        if ok:
+            (report.data["tables_existing"] if existed else report.data["tables_created"]).append(
+                table_name
+            )
+
+    # 5) Row filter on created_by for every table (idempotent — SET replaces).
+    #    May fail on a restart once ownership has moved off the SP → captured as WARNING.
+    for table_name in schema.ALL_TABLE_NAMES:
+        stmt = (
+            f"ALTER TABLE {fq}.{quote_ident(table_name)} "
+            f"SET ROW FILTER {fq}.{quote_ident(schema.ROW_FILTER_FUNCTION)} ON (created_by)"
+        )
+        report.attempt(f"row_filter:{table_name}", lambda s=stmt: _run(w, wh, s))
+
+    # 6) Grants for the OBO user group (HISTORY_GRANTEE). Done BEFORE the ownership
+    #    handoff (while the SP still owns the objects), so the grants reliably apply
+    #    and persist past the OWNER TO. USE CATALOG may warn if the SP can't grant at
+    #    the catalog level — that grant is ultimately the operator's responsibility.
+    grantee = _quote_principal(settings.history_grantee)
+    report.attempt(
+        "grant_use_catalog:grantee",
+        lambda: _run(w, wh, f"GRANT USE CATALOG ON CATALOG {cat} TO {grantee}"),
+    )
+    report.attempt(
+        "grant_schema:grantee",
+        lambda: _run(w, wh, f"GRANT USE SCHEMA, SELECT, MODIFY ON SCHEMA {fq} TO {grantee}"),
+    )
+
+    # 7) Ensure the app SP keeps SELECT/MODIFY after it stops being owner (spec §7.1).
+    try:
+        sp_name = w.current_user.me().user_name
+    except Exception as exc:  # noqa: BLE001
+        sp_name = None
+        report.warn("resolve_sp_identity", exc)
+    if sp_name:
+        sp = _quote_principal(sp_name)
+        report.attempt(
+            "grant_schema:app_sp",
+            lambda: _run(w, wh, f"GRANT USE SCHEMA, SELECT, MODIFY ON SCHEMA {fq} TO {sp}"),
+        )
+
+    # 8) Durable ownership handoff to HISTORY_OWNER_GROUP (schema + each table; the
+    #    function transfer is admin-gated). Ownership does NOT inherit — do each one.
+    #    Failure here is EXPECTED when the SP isn't a member of the group → WARNING,
+    #    and an operator/metastore admin runs the one-time OWNER TO (spec §7.1/§10).
+    owner = _quote_principal(settings.history_owner_group)
+    report.attempt(
+        "owner_to:schema",
+        lambda: _run(w, wh, f"ALTER SCHEMA {fq} OWNER TO {owner}"),
+    )
+    for table_name in schema.ALL_TABLE_NAMES:
+        stmt = f"ALTER TABLE {fq}.{quote_ident(table_name)} OWNER TO {owner}"
+        report.attempt(f"owner_to:{table_name}", lambda s=stmt: _run(w, wh, s))
+    report.attempt(
+        "owner_to:only_mine",
+        lambda: _run(
+            w,
+            wh,
+            f"ALTER FUNCTION {fq}.{quote_ident(schema.ROW_FILTER_FUNCTION)} OWNER TO {owner}",
+        ),
+    )
+
+    # Bootstrap "succeeded" if the data path is usable: schema + all tables exist.
+    created_or_existing = set(report.data["tables_created"]) | set(report.data["tables_existing"])
+    report.data["ok"] = set(schema.ALL_TABLE_NAMES).issubset(created_or_existing)
+    return report.data

--- a/genie-code/mcp-genie-space-history/app/server/schema.py
+++ b/genie-code/mcp-genie-space-history/app/server/schema.py
@@ -1,0 +1,250 @@
+"""UC Delta schema — the 7 per-artifact tables + the ``only_mine`` row filter (spec §7.1).
+
+This module is the single source of truth for:
+  * the DDL of every table (exactly per spec §7.1, with the F-4 TBLPROPERTIES);
+  * which logical-PK column identifies each table (for ``get_artifact``);
+  * how each table projects onto the normalized ``list_history`` columns
+    (``{id, type, version, created_at, created_by, summary, decision}``).
+
+JSON columns default to ``STRING``; ``VARIANT`` is opt-in behind
+``Settings.use_variant`` (spec §7.1/§12 #3) — never hard-required.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+ROW_FILTER_FUNCTION = "only_mine"
+
+# Required on every table because of the DEFAULT current_timestamp()/current_user()
+# columns (P0 finding F-4) — alongside row tracking.
+_TBLPROPERTIES = (
+    "TBLPROPERTIES (\n"
+    "  delta.enableRowTracking = true,\n"
+    "  'delta.feature.allowColumnDefaults' = 'supported'\n"
+    ")"
+)
+
+
+def _json_type(use_variant: bool) -> str:
+    """JSON column type: ``STRING`` by default, ``VARIANT`` only when opted-in (§12 #3)."""
+    return "VARIANT" if use_variant else "STRING"
+
+
+# --- table names ------------------------------------------------------------
+CONFIG_SNAPSHOTS = "config_snapshots"
+OPTIMIZATION_RUNS = "optimization_runs"
+EVAL_RESULTS = "eval_results"
+DIAGNOSE_REPORTS = "diagnose_reports"
+QUERY_REPORTS = "query_reports"
+DESIGN_PROPOSALS = "design_proposals"
+METRIC_VIEW_ARTIFACTS = "metric_view_artifacts"
+
+REPORT_TABLES = (DIAGNOSE_REPORTS, QUERY_REPORTS, DESIGN_PROPOSALS, METRIC_VIEW_ARTIFACTS)
+
+
+# ``save_report`` routes an ``artifact_type`` to its report table (spec §6).
+# Unknown artifact_types are rejected by the tool layer.
+ARTIFACT_TYPE_TO_REPORT_TABLE: dict[str, str] = {
+    "diagnose_report": DIAGNOSE_REPORTS,
+    "query_report": QUERY_REPORTS,
+    "design_proposal": DESIGN_PROPOSALS,
+    "metric_view_ddl": METRIC_VIEW_ARTIFACTS,
+}
+
+
+@dataclass(frozen=True)
+class TableSpec:
+    """How one artifact table participates in ``list_history`` / ``get_artifact``."""
+
+    name: str
+    id_column: str  # logical PK — what get_artifact resolves an id against
+    type_label: str  # the value surfaced as list_history.type / get_artifact.type
+    # SQL expressions projecting this table onto the normalized list_history columns.
+    version_expr: str
+    summary_expr: str
+    decision_expr: str
+
+
+# Resolution order for get_artifact (config first — the rollback-critical table).
+TABLE_SPECS: tuple[TableSpec, ...] = (
+    TableSpec(
+        name=CONFIG_SNAPSHOTS,
+        id_column="config_version_id",
+        type_label="config_snapshot",
+        version_expr="version",
+        summary_expr="change_summary",
+        decision_expr="CAST(NULL AS STRING)",
+    ),
+    TableSpec(
+        name=OPTIMIZATION_RUNS,
+        id_column="run_id",
+        type_label="optimization_run",
+        version_expr="CAST(NULL AS BIGINT)",
+        summary_expr="change_summary",
+        decision_expr="decision",
+    ),
+    TableSpec(
+        name=EVAL_RESULTS,
+        id_column="eval_run_id",
+        type_label="eval_result",
+        version_expr="CAST(NULL AS BIGINT)",
+        summary_expr="primary_failure",
+        decision_expr="assessment",
+    ),
+    TableSpec(
+        name=DIAGNOSE_REPORTS,
+        id_column="artifact_id",
+        type_label="diagnose_report",
+        version_expr="CAST(NULL AS BIGINT)",
+        summary_expr="summary",
+        decision_expr="CAST(NULL AS STRING)",
+    ),
+    TableSpec(
+        name=QUERY_REPORTS,
+        id_column="artifact_id",
+        type_label="query_report",
+        version_expr="CAST(NULL AS BIGINT)",
+        summary_expr="summary",
+        decision_expr="CAST(NULL AS STRING)",
+    ),
+    TableSpec(
+        name=DESIGN_PROPOSALS,
+        id_column="artifact_id",
+        type_label="design_proposal",
+        version_expr="CAST(NULL AS BIGINT)",
+        summary_expr="summary",
+        decision_expr="CAST(NULL AS STRING)",
+    ),
+    TableSpec(
+        name=METRIC_VIEW_ARTIFACTS,
+        id_column="artifact_id",
+        type_label="metric_view_ddl",
+        version_expr="CAST(NULL AS BIGINT)",
+        summary_expr="summary",
+        decision_expr="CAST(NULL AS STRING)",
+    ),
+)
+
+# Lookup of type_label -> spec, for the optional list_history artifact_type filter.
+TYPE_LABEL_TO_SPEC: dict[str, TableSpec] = {s.type_label: s for s in TABLE_SPECS}
+
+# JSON columns per table (STRING by default, VARIANT opt-in).
+JSON_COLUMNS: dict[str, tuple[str, ...]] = {
+    CONFIG_SNAPSHOTS: ("config_json", "diff_patch"),
+    **{t: ("scores_findings",) for t in REPORT_TABLES},
+}
+
+
+# ---------------------------------------------------------------------------
+# DDL builders — each takes a pre-quoted ``fq`` schema prefix (``cat`.`schema``).
+# ---------------------------------------------------------------------------
+def config_snapshots_ddl(fq: str, *, use_variant: bool) -> str:
+    j = _json_type(use_variant)
+    return f"""
+CREATE TABLE IF NOT EXISTS {fq}.{CONFIG_SNAPSHOTS} (
+  config_version_id   STRING    NOT NULL,
+  space_id            STRING    NOT NULL,
+  version             BIGINT    NOT NULL,
+  parent_version_id   STRING,
+  created_at          TIMESTAMP DEFAULT current_timestamp(),
+  created_by          STRING    DEFAULT current_user(),
+  skill_name          STRING,
+  config_json         {j},
+  config_hash         STRING,
+  diff_patch          {j},
+  changed_surfaces    ARRAY<STRING>,
+  etag                STRING,
+  run_id              STRING,
+  rollback_reference  STRING,
+  change_summary      STRING
+) USING DELTA {_TBLPROPERTIES}
+""".strip()
+
+
+def optimization_runs_ddl(fq: str) -> str:
+    return f"""
+CREATE TABLE IF NOT EXISTS {fq}.{OPTIMIZATION_RUNS} (
+  run_id                   STRING NOT NULL,
+  space_id                 STRING NOT NULL,
+  created_at               TIMESTAMP DEFAULT current_timestamp(),
+  created_by               STRING DEFAULT current_user(),
+  baseline_score           DOUBLE,
+  candidate_score          DOUBLE,
+  score_delta              DOUBLE,
+  fixed_count              INT,
+  regressed_count          INT,
+  unchanged_count          INT,
+  excluded_count           INT,
+  decision                 STRING,
+  parent_config_version_id STRING,
+  result_config_version_id STRING,
+  change_summary           STRING
+) USING DELTA {_TBLPROPERTIES}
+""".strip()
+
+
+def eval_results_ddl(fq: str) -> str:
+    return f"""
+CREATE TABLE IF NOT EXISTS {fq}.{EVAL_RESULTS} (
+  eval_run_id             STRING NOT NULL,
+  run_id                  STRING NOT NULL,
+  space_id                STRING NOT NULL,
+  created_at              TIMESTAMP DEFAULT current_timestamp(),
+  created_by              STRING DEFAULT current_user(),
+  question_id             STRING,
+  assessment              STRING,
+  primary_failure         STRING,
+  baseline_sql_hash       STRING,
+  candidate_sql_hash      STRING,
+  baseline_result_digest  STRING,
+  candidate_result_digest STRING,
+  latency_ms              BIGINT
+) USING DELTA {_TBLPROPERTIES}
+""".strip()
+
+
+def report_table_ddl(fq: str, table_name: str, *, use_variant: bool) -> str:
+    j = _json_type(use_variant)
+    return f"""
+CREATE TABLE IF NOT EXISTS {fq}.{table_name} (
+  artifact_id         STRING    NOT NULL,
+  space_id            STRING    NOT NULL,
+  created_at          TIMESTAMP DEFAULT current_timestamp(),
+  created_by          STRING    DEFAULT current_user(),
+  skill_name          STRING,
+  title               STRING,
+  content_md          STRING,
+  summary             STRING,
+  scores_findings     {j},
+  run_id              STRING,
+  config_version_id   STRING,
+  redacted            BOOLEAN   DEFAULT true
+) USING DELTA {_TBLPROPERTIES}
+""".strip()
+
+
+def only_mine_function_ddl(fq: str) -> str:
+    """The per-user row-filter function (spec §7.1)."""
+    return (
+        f"CREATE FUNCTION IF NOT EXISTS {fq}.{ROW_FILTER_FUNCTION}(owner STRING)\n"
+        f"  RETURN owner = SESSION_USER()"
+    )
+
+
+def all_table_ddls(fq: str, *, use_variant: bool) -> list[tuple[str, str]]:
+    """``(table_name, ddl)`` for every one of the 7 tables, in creation order."""
+    return [
+        (CONFIG_SNAPSHOTS, config_snapshots_ddl(fq, use_variant=use_variant)),
+        (OPTIMIZATION_RUNS, optimization_runs_ddl(fq)),
+        (EVAL_RESULTS, eval_results_ddl(fq)),
+        *[(t, report_table_ddl(fq, t, use_variant=use_variant)) for t in REPORT_TABLES],
+    ]
+
+
+ALL_TABLE_NAMES: tuple[str, ...] = (
+    CONFIG_SNAPSHOTS,
+    OPTIMIZATION_RUNS,
+    EVAL_RESULTS,
+    *REPORT_TABLES,
+)

--- a/genie-code/mcp-genie-space-history/app/server/schema.py
+++ b/genie-code/mcp-genie-space-history/app/server/schema.py
@@ -72,7 +72,9 @@ TABLE_SPECS: tuple[TableSpec, ...] = (
         name=CONFIG_SNAPSHOTS,
         id_column="config_version_id",
         type_label="config_snapshot",
-        version_expr="version",
+        # No monotonic version counter: config snapshots are ordered/identified by
+        # created_at + config_version_id, so this projects NULL like every other table.
+        version_expr="CAST(NULL AS BIGINT)",
         summary_expr="change_summary",
         decision_expr="CAST(NULL AS STRING)",
     ),
@@ -145,7 +147,6 @@ def config_snapshots_ddl(fq: str, *, use_variant: bool) -> str:
 CREATE TABLE IF NOT EXISTS {fq}.{CONFIG_SNAPSHOTS} (
   config_version_id   STRING    NOT NULL,
   space_id            STRING    NOT NULL,
-  version             BIGINT    NOT NULL,
   parent_version_id   STRING,
   created_at          TIMESTAMP DEFAULT current_timestamp(),
   created_by          STRING    DEFAULT current_user(),

--- a/genie-code/mcp-genie-space-history/app/server/sql.py
+++ b/genie-code/mcp-genie-space-history/app/server/sql.py
@@ -1,0 +1,162 @@
+"""SQL execution + the param/result adapter (spec §11).
+
+Two layers, deliberately split so the storage logic can be unit-tested with NO
+live workspace:
+
+  * :class:`Param` / :class:`QueryResult` — pure, SDK-free value objects the
+    store builds and consumes. Tests inject a fake executor returning
+    ``QueryResult`` directly.
+  * :func:`exec_sql` / :func:`make_sql_exec` — the production adapter that talks
+    to the Databricks SDK ``statement_execution`` API. Server-side parameter
+    binding is used everywhere; user data is NEVER string-interpolated into SQL.
+
+Identifier safety: catalog/schema/table names come from env config (not caller
+args), but we still validate + backtick-quote every identifier so a stray value
+can never break out into injected SQL.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Callable, Optional, Sequence
+
+from databricks.sdk import WorkspaceClient
+from databricks.sdk.service.sql import StatementParameterListItem, StatementState
+
+
+class SqlError(RuntimeError):
+    """A SQL statement reached a non-SUCCEEDED terminal state."""
+
+    def __init__(self, message: str, *, state: Optional[str] = None, statement: str = ""):
+        super().__init__(message)
+        self.state = state
+        self.statement = statement
+
+
+# Identifiers are a restricted charset; anything else is rejected outright.
+_IDENT_RE = re.compile(r"^[A-Za-z0-9_]+$")
+
+
+def quote_ident(name: str) -> str:
+    """Validate and backtick-quote a single SQL identifier."""
+    if not name or not _IDENT_RE.match(name):
+        raise ValueError(f"unsafe SQL identifier: {name!r}")
+    return f"`{name}`"
+
+
+def quote_fqn(*parts: str) -> str:
+    """Validate + quote each part of a dotted name (``catalog.schema.table``)."""
+    return ".".join(quote_ident(p) for p in parts)
+
+
+@dataclass(frozen=True)
+class Param:
+    """A server-side bound parameter (SDK-free; the adapter maps it to the SDK type).
+
+    ``value=None`` binds a SQL NULL. ``type`` is the SQL type name (e.g. ``BIGINT``,
+    ``BOOLEAN``); when omitted the value binds as STRING and the server implicitly
+    casts to the column type.
+    """
+
+    name: str
+    value: Optional[str]
+    type: Optional[str] = None
+
+
+@dataclass
+class QueryResult:
+    """Normalized result of a query — column names + row values, SDK-shape-free."""
+
+    columns: list[str] = field(default_factory=list)
+    rows: list[list] = field(default_factory=list)
+
+    def dicts(self) -> list[dict]:
+        return [dict(zip(self.columns, row, strict=False)) for row in self.rows]
+
+    def first(self) -> Optional[dict]:
+        ds = self.dicts()
+        return ds[0] if ds else None
+
+    def scalar(self):
+        """The single (row 0, col 0) value, or ``None`` if there are no rows."""
+        return self.rows[0][0] if self.rows and self.rows[0] else None
+
+
+# A storage-facing SQL executor: run a statement (with optional bound params) and
+# return a normalized result. Production builds this from a WorkspaceClient; tests
+# supply a fake.
+SqlExec = Callable[[str, Optional[Sequence[Param]]], QueryResult]
+
+
+def exec_sql(
+    w: WorkspaceClient,
+    warehouse_id: str,
+    statement: str,
+    *,
+    parameters: Optional[list[StatementParameterListItem]] = None,
+    timeout_s: int = 120,
+):
+    """Run one SQL statement on a warehouse, blocking until a terminal state.
+
+    Uses server-side parameter binding when ``parameters`` is supplied (spec §11).
+    Raises :class:`SqlError` on any non-SUCCEEDED terminal state, carrying the
+    warehouse's own error message.
+    """
+    resp = w.statement_execution.execute_statement(
+        statement=statement,
+        warehouse_id=warehouse_id,
+        wait_timeout="30s",
+        parameters=parameters,
+    )
+    statement_id = resp.statement_id
+    if statement_id is None:
+        raise SqlError("no statement_id returned by warehouse", state="ERROR", statement=statement)
+    deadline = time.time() + timeout_s
+    while resp.status and resp.status.state in (StatementState.PENDING, StatementState.RUNNING):
+        if time.time() > deadline:
+            raise SqlError("statement timed out", state="TIMEOUT", statement=statement)
+        time.sleep(1.0)
+        resp = w.statement_execution.get_statement(statement_id)
+
+    state = resp.status.state if resp.status else None
+    if state != StatementState.SUCCEEDED:
+        err = ""
+        if resp.status and resp.status.error:
+            err = resp.status.error.message or ""
+        raise SqlError(
+            f"SQL {state}: {err}",
+            state=state.value if state else None,
+            statement=statement,
+        )
+    return resp
+
+
+def to_query_result(resp) -> QueryResult:
+    """Convert an SDK ``StatementResponse`` to a normalized :class:`QueryResult`."""
+    columns: list[str] = []
+    if resp is not None and resp.manifest and resp.manifest.schema and resp.manifest.schema.columns:
+        columns = [c.name or "" for c in resp.manifest.schema.columns]
+    rows: list[list] = []
+    if resp is not None and resp.result and resp.result.data_array:
+        rows = [list(r) for r in resp.result.data_array]
+    return QueryResult(columns=columns, rows=rows)
+
+
+def _to_sdk_params(
+    parameters: Optional[Sequence[Param]],
+) -> Optional[list[StatementParameterListItem]]:
+    if not parameters:
+        return None
+    return [StatementParameterListItem(name=p.name, value=p.value, type=p.type) for p in parameters]
+
+
+def make_sql_exec(w: WorkspaceClient, warehouse_id: str) -> SqlExec:
+    """Build the production :data:`SqlExec` bound to a client + warehouse."""
+
+    def run(statement: str, parameters: Optional[Sequence[Param]] = None) -> QueryResult:
+        resp = exec_sql(w, warehouse_id, statement, parameters=_to_sdk_params(parameters))
+        return to_query_result(resp)
+
+    return run

--- a/genie-code/mcp-genie-space-history/app/server/store.py
+++ b/genie-code/mcp-genie-space-history/app/server/store.py
@@ -1,0 +1,333 @@
+"""UC storage adapter — :class:`UCTableStore` (spec §6/§7/§11).
+
+All user data is bound server-side (:class:`~server.sql.Param`); nothing is
+string-interpolated into SQL. Identifiers are validated + backtick-quoted.
+
+The store is SDK-shape-free: it talks to a :data:`~server.sql.SqlExec` callable
+that returns a normalized :class:`~server.sql.QueryResult`. Production wires that
+to a real warehouse via :func:`~server.sql.make_sql_exec`; tests inject a fake.
+Each write method takes the resolved ``user_name`` explicitly (the tool layer
+resolves it from ``current_user.me()`` — spec §6) and stamps ``created_at``
+server-side via ``current_timestamp()``.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import uuid
+from typing import Any, Optional, Sequence
+
+from . import schema
+from .config import Settings
+from .sql import Param, QueryResult, SqlExec, quote_ident
+
+
+def sha256_hex(text: str) -> str:
+    """sha256 hex digest of a UTF-8 string (config_hash / idempotency basis)."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _derive_id(namespace: str, key: str) -> str:
+    """Deterministic 32-char hex id from (namespace, idempotency key).
+
+    Same (namespace, key) always yields the same id, so a retried write resolves
+    to the same row instead of inserting a duplicate (spec §6 idempotency). The
+    32-char hex shape matches the spec's id convention.
+    """
+    return hashlib.sha256(f"{namespace}\x00{key}".encode("utf-8")).hexdigest()[:32]
+
+
+def _new_id() -> str:
+    """A fresh random 32-char hex id (used when no idempotency key is supplied)."""
+    return uuid.uuid4().hex
+
+
+def _infer_type(value: Any) -> Optional[str]:
+    # bool is a subclass of int — check it first.
+    if isinstance(value, bool):
+        return "BOOLEAN"
+    if isinstance(value, int):
+        return "BIGINT"
+    if isinstance(value, float):
+        return "DOUBLE"
+    return None
+
+
+def _to_param_str(value: Any) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+class _InsertBuilder:
+    """Accumulates columns/value-expressions/params for a single INSERT.
+
+    Columns whose value is ``None`` are omitted entirely so the table's DEFAULTs
+    (or NULL) apply — this avoids binding NULLs into typed/JSON/array columns.
+    """
+
+    def __init__(self) -> None:
+        self._cols: list[str] = []
+        self._exprs: list[str] = []
+        self._params: list[Param] = []
+
+    def set(self, col: str, value: Any) -> None:
+        if value is None:
+            return
+        self._cols.append(quote_ident(col))
+        self._exprs.append(f":{col}")
+        self._params.append(Param(col, _to_param_str(value), _infer_type(value)))
+
+    def set_json(self, col: str, value: Any, *, use_variant: bool) -> None:
+        if value is None:
+            return
+        text = value if isinstance(value, str) else json.dumps(value)
+        self._cols.append(quote_ident(col))
+        # parse_json(...) returns VARIANT; only valid when the column is VARIANT.
+        self._exprs.append(f"parse_json(:{col})" if use_variant else f":{col}")
+        self._params.append(Param(col, text, None))
+
+    def set_array(self, col: str, values: Optional[Sequence[str]]) -> None:
+        if values is None:
+            return
+        self._cols.append(quote_ident(col))
+        self._exprs.append(f"from_json(:{col}, 'ARRAY<STRING>')")
+        self._params.append(Param(col, json.dumps(list(values)), None))
+
+    def set_raw(self, col: str, expr: str) -> None:
+        """A column set to a raw SQL expression (e.g. ``current_timestamp()``)."""
+        self._cols.append(quote_ident(col))
+        self._exprs.append(expr)
+
+    def build(self, fq_table: str) -> tuple[str, list[Param]]:
+        cols = ", ".join(self._cols)
+        exprs = ", ".join(self._exprs)
+        return f"INSERT INTO {fq_table} ({cols}) VALUES ({exprs})", self._params
+
+
+class UCTableStore:
+    """Read/write adapter over the ``genie_space_history`` tables."""
+
+    def __init__(self, sql_exec: SqlExec, settings: Settings, *, user_name: str):
+        self._run = sql_exec
+        self.settings = settings
+        self.user_name = user_name
+
+    # --- identifiers -------------------------------------------------------
+    @property
+    def _fq_schema(self) -> str:
+        cat = quote_ident(self.settings.history_catalog)
+        sch = quote_ident(self.settings.history_schema)
+        return f"{cat}.{sch}"
+
+    def _fq_table(self, table_name: str) -> str:
+        return f"{self._fq_schema}.{quote_ident(table_name)}"
+
+    # --- helpers -----------------------------------------------------------
+    def _next_version(self, space_id: str) -> int:
+        """Monotonic per-``space_id`` version (1, 2, 3…).
+
+        Under OBO + the ``only_mine`` row filter this counts only the caller's own
+        snapshots for the space (other users' rows are invisible) — the intended
+        per-user history semantics (spec §5).
+        """
+        sql = (
+            f"SELECT COALESCE(MAX(version), 0) + 1 AS next_version "
+            f"FROM {self._fq_table(schema.CONFIG_SNAPSHOTS)} WHERE space_id = :space_id"
+        )
+        result = self._run(sql, [Param("space_id", space_id)])
+        value = result.scalar()
+        return int(value) if value is not None else 1
+
+    def _find_by_id(self, spec: schema.TableSpec, id_value: str) -> Optional[dict]:
+        sql = (
+            f"SELECT * FROM {self._fq_table(spec.name)} "
+            f"WHERE {quote_ident(spec.id_column)} = :id LIMIT 1"
+        )
+        return self._run(sql, [Param("id", id_value)]).first()
+
+    # --- save_config_snapshot ---------------------------------------------
+    def save_config_snapshot(
+        self,
+        *,
+        space_id: str,
+        serialized_space: str,
+        etag: Optional[str] = None,
+        parent_version_id: Optional[str] = None,
+        run_id: Optional[str] = None,
+        changed_surfaces: Optional[Sequence[str]] = None,
+        change_summary: Optional[str] = None,
+        rollback_reference: Optional[str] = None,
+        skill_name: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
+    ) -> dict:
+        """Persist a config version; returns ``{config_version_id, version, config_hash, etag}``.
+
+        Server-computed: ``config_hash`` (sha256 of ``serialized_space``), a monotonic
+        per-space ``version``, and the logical id. ``idempotency_key`` defaults to
+        ``config_hash`` so re-saving identical content is a no-op that returns the
+        existing row (spec §6).
+        """
+        config_hash = sha256_hex(serialized_space)
+        idem = idempotency_key or config_hash
+        config_version_id = _derive_id(f"config:{space_id}", idem)
+
+        existing = self._find_by_id(schema.TABLE_SPECS[0], config_version_id)
+        if existing is not None:
+            return {
+                "config_version_id": existing.get("config_version_id"),
+                "version": int(existing["version"])
+                if existing.get("version") is not None
+                else None,
+                "config_hash": existing.get("config_hash"),
+                "etag": existing.get("etag"),
+                "deduplicated": True,
+            }
+
+        version = self._next_version(space_id)
+        b = _InsertBuilder()
+        b.set("config_version_id", config_version_id)
+        b.set("space_id", space_id)
+        b.set("version", version)
+        b.set("parent_version_id", parent_version_id)
+        b.set_raw("created_at", "current_timestamp()")
+        b.set("created_by", self.user_name)
+        b.set("skill_name", skill_name)
+        b.set_json("config_json", serialized_space, use_variant=self.settings.use_variant)
+        b.set("config_hash", config_hash)
+        b.set_array("changed_surfaces", changed_surfaces)
+        b.set("etag", etag)
+        b.set("run_id", run_id)
+        b.set("rollback_reference", rollback_reference)
+        b.set("change_summary", change_summary)
+        sql, params = b.build(self._fq_table(schema.CONFIG_SNAPSHOTS))
+        self._run(sql, params)
+
+        return {
+            "config_version_id": config_version_id,
+            "version": version,
+            "config_hash": config_hash,
+            "etag": etag,
+            "deduplicated": False,
+        }
+
+    # --- save_report -------------------------------------------------------
+    def save_report(
+        self,
+        *,
+        space_id: str,
+        artifact_type: str,
+        title: str,
+        content_md: str,
+        summary: Optional[str] = None,
+        scores_findings: Optional[Any] = None,
+        run_id: Optional[str] = None,
+        config_version_id: Optional[str] = None,
+        skill_name: Optional[str] = None,
+        redacted: bool = True,
+        idempotency_key: Optional[str] = None,
+    ) -> dict:
+        """Persist a Markdown report to the routed table; returns ``{artifact_id}``.
+
+        The caller has already validated ``artifact_type``; we resolve its table here.
+        ``idempotency_key`` (when supplied) makes retries return the same row (§6).
+        """
+        table_name = schema.ARTIFACT_TYPE_TO_REPORT_TABLE[artifact_type]
+        spec = schema.TYPE_LABEL_TO_SPEC[artifact_type]
+
+        if idempotency_key:
+            artifact_id = _derive_id(f"report:{space_id}:{artifact_type}", idempotency_key)
+            existing = self._find_by_id(spec, artifact_id)
+            if existing is not None:
+                return {"artifact_id": existing.get("artifact_id"), "deduplicated": True}
+        else:
+            artifact_id = _new_id()
+
+        b = _InsertBuilder()
+        b.set("artifact_id", artifact_id)
+        b.set("space_id", space_id)
+        b.set_raw("created_at", "current_timestamp()")
+        b.set("created_by", self.user_name)
+        b.set("skill_name", skill_name)
+        b.set("title", title)
+        b.set("content_md", content_md)
+        b.set("summary", summary)
+        b.set_json("scores_findings", scores_findings, use_variant=self.settings.use_variant)
+        b.set("run_id", run_id)
+        b.set("config_version_id", config_version_id)
+        b.set("redacted", redacted)
+        sql, params = b.build(self._fq_table(table_name))
+        self._run(sql, params)
+        return {"artifact_id": artifact_id, "deduplicated": False}
+
+    # --- list_history ------------------------------------------------------
+    def list_history(
+        self,
+        *,
+        space_id: str,
+        type_label: Optional[str] = None,
+        limit: int = 50,
+        since: Optional[str] = None,
+    ) -> list[dict]:
+        """UNION across the artifact tables for a space → normalized timeline rows.
+
+        Each row: ``{id, type, version, created_at, created_by, summary, decision}``.
+        ``type_label`` (optional) restricts to a single artifact type; ``since``
+        filters on ``created_at``. ``limit`` is a server-validated integer, so it
+        is inlined safely (parameter markers are not supported in LIMIT).
+        """
+        specs: Sequence[schema.TableSpec]
+        specs = [schema.TYPE_LABEL_TO_SPEC[type_label]] if type_label else schema.TABLE_SPECS
+
+        params: list[Param] = [Param("space_id", space_id)]
+        since_clause = ""
+        if since:
+            since_clause = " AND created_at >= :since"
+            params.append(Param("since", since, "TIMESTAMP"))
+
+        subqueries = []
+        for spec in specs:
+            subqueries.append(
+                f"SELECT {quote_ident(spec.id_column)} AS id, "
+                f"'{spec.type_label}' AS type, "
+                f"{spec.version_expr} AS version, "
+                f"created_at, created_by, "
+                f"{spec.summary_expr} AS summary, "
+                f"{spec.decision_expr} AS decision "
+                f"FROM {self._fq_table(spec.name)} "
+                f"WHERE space_id = :space_id{since_clause}"
+            )
+
+        safe_limit = max(1, min(int(limit), 1000))
+        union = "\nUNION ALL\n".join(subqueries)
+        sql = f"SELECT * FROM (\n{union}\n) ORDER BY created_at DESC LIMIT {safe_limit}"
+        return self._run(sql, params).dicts()
+
+    # --- get_artifact ------------------------------------------------------
+    def get_artifact(self, id_value: str) -> Optional[dict]:
+        """Resolve an id across all tables; returns the full record or ``None``.
+
+        Searches each table's logical-PK column in order (config first). Optimization
+        runs / eval results have no P1 write tool but are resolved here (spec §6).
+        """
+        for spec in schema.TABLE_SPECS:
+            record = self._find_by_id(spec, id_value)
+            if record is not None:
+                return {
+                    "id": id_value,
+                    "type": spec.type_label,
+                    "table": spec.name,
+                    "record": record,
+                }
+        return None
+
+    # exposed for the optional list_history filter validation in the tool layer.
+    @staticmethod
+    def known_type_labels() -> set[str]:
+        return set(schema.TYPE_LABEL_TO_SPEC.keys())
+
+
+def query_result_to_dicts(result: QueryResult) -> list[dict]:
+    """Convenience re-export for callers that hold a raw QueryResult."""
+    return result.dicts()

--- a/genie-code/mcp-genie-space-history/app/server/store.py
+++ b/genie-code/mcp-genie-space-history/app/server/store.py
@@ -6,9 +6,19 @@ string-interpolated into SQL. Identifiers are validated + backtick-quoted.
 The store is SDK-shape-free: it talks to a :data:`~server.sql.SqlExec` callable
 that returns a normalized :class:`~server.sql.QueryResult`. Production wires that
 to a real warehouse via :func:`~server.sql.make_sql_exec`; tests inject a fake.
-Each write method takes the resolved ``user_name`` explicitly (the tool layer
-resolves it from ``current_user.me()`` — spec §6) and stamps ``created_at``
-server-side via ``current_timestamp()``.
+
+``created_at`` and ``created_by`` are stamped **server-side** via
+``current_timestamp()`` / ``current_user()`` so that ``created_by`` is guaranteed
+to equal the ``SESSION_USER()`` the ``only_mine`` row filter compares against
+(spec §5/§7.1) — i.e. a user can always read back their own writes.
+
+Concurrency note (spec §6/§11): UC SQL warehouses enforce **no** PK/unique
+constraints or row locks and give us no multi-statement transaction, so
+``save_config_snapshot`` cannot make ``MAX(version)+1 → INSERT`` atomic. We use a
+bounded **optimistic-retry**: insert, then verify there is no colliding version /
+duplicate id, and on a version collision back out our row and retry. A residual
+race window remains (see ``save_config_snapshot`` + README); it is documented, not
+silently ignored.
 """
 
 from __future__ import annotations
@@ -20,7 +30,11 @@ from typing import Any, Optional, Sequence
 
 from . import schema
 from .config import Settings
+from .errors import StorageContentionError
 from .sql import Param, QueryResult, SqlExec, quote_ident
+
+# Bounded optimistic-retry budget for version allocation under concurrency.
+MAX_SAVE_ATTEMPTS = 5
 
 
 def sha256_hex(text: str) -> str:
@@ -147,6 +161,51 @@ class UCTableStore:
         )
         return self._run(sql, [Param("id", id_value)]).first()
 
+    def _snapshot_conflicts(
+        self, space_id: str, config_version_id: str, version: int
+    ) -> list[dict]:
+        """Post-insert verification: rows sharing our id OR our version for this space.
+
+        Used to detect (a) a concurrent write that landed the same idempotency-derived
+        id and (b) a concurrent write that grabbed the same ``version`` with a *different*
+        config. Runs OBO, so it sees only the caller's own rows — but concurrent writes
+        for the same (space, user) are by the same identity, hence visible here.
+        """
+        sql = (
+            f"SELECT config_version_id, version, config_hash, etag "
+            f"FROM {self._fq_table(schema.CONFIG_SNAPSHOTS)} "
+            f"WHERE space_id = :space_id AND (config_version_id = :id OR version = :version)"
+        )
+        params = [
+            Param("space_id", space_id),
+            Param("id", config_version_id),
+            Param("version", str(version), "BIGINT"),
+        ]
+        return self._run(sql, params).dicts()
+
+    def _delete_snapshot(self, config_version_id: str, version: int) -> None:
+        """Back out exactly our just-inserted row (to resolve a version collision)."""
+        sql = (
+            f"DELETE FROM {self._fq_table(schema.CONFIG_SNAPSHOTS)} "
+            f"WHERE config_version_id = :id AND version = :version"
+        )
+        self._run(
+            sql,
+            [Param("id", config_version_id), Param("version", str(version), "BIGINT")],
+        )
+
+    @staticmethod
+    def _dedup_result(row: dict) -> dict:
+        """Shape an existing config_snapshots row as a deduplicated save result."""
+        v = row.get("version")
+        return {
+            "config_version_id": row.get("config_version_id"),
+            "version": int(v) if v is not None else None,
+            "config_hash": row.get("config_hash"),
+            "etag": row.get("etag"),
+            "deduplicated": True,
+        }
+
     # --- save_config_snapshot ---------------------------------------------
     def save_config_snapshot(
         self,
@@ -165,52 +224,92 @@ class UCTableStore:
         """Persist a config version; returns ``{config_version_id, version, config_hash, etag}``.
 
         Server-computed: ``config_hash`` (sha256 of ``serialized_space``), a monotonic
-        per-space ``version``, and the logical id. ``idempotency_key`` defaults to
-        ``config_hash`` so re-saving identical content is a no-op that returns the
-        existing row (spec §6).
+        per-space ``version``, and the logical id (deterministic from the idempotency
+        key — which defaults to ``config_hash``, so re-saving identical content is a
+        no-op that returns the existing row, spec §6).
+
+        Concurrency (spec §11): UC has no unique constraints / row locks / cross-statement
+        transactions, so we run a bounded optimistic-retry — insert, then verify there is
+        no colliding version (different config, same version) or duplicate id; on a version
+        collision we back out our row and retry up to ``MAX_SAVE_ATTEMPTS``, raising a clean
+        :class:`StorageContentionError` if it cannot converge.
+
+        **Residual race (documented, not silently ignored):** two concurrent writes with the
+        *same idempotency key* can each pass read-before-write and land byte-identical rows;
+        a targeted DELETE can't distinguish them, so a transient duplicate may persist (the
+        logical result is still single + correct). Single-writer use — the normal skill
+        path — is unaffected. See the README "Concurrency" note.
         """
         config_hash = sha256_hex(serialized_space)
         idem = idempotency_key or config_hash
         config_version_id = _derive_id(f"config:{space_id}", idem)
+        spec = schema.TABLE_SPECS[0]
 
-        existing = self._find_by_id(schema.TABLE_SPECS[0], config_version_id)
-        if existing is not None:
+        for _attempt in range(MAX_SAVE_ATTEMPTS):
+            # 1) Idempotency read-before-write (re-checked every attempt: a concurrent
+            #    writer sharing this key may have committed since the previous try).
+            existing = self._find_by_id(spec, config_version_id)
+            if existing is not None:
+                return self._dedup_result(existing)
+
+            # 2) Allocate a version and insert.
+            version = self._next_version(space_id)
+            b = _InsertBuilder()
+            b.set("config_version_id", config_version_id)
+            b.set("space_id", space_id)
+            b.set("version", version)
+            b.set("parent_version_id", parent_version_id)
+            b.set_raw("created_at", "current_timestamp()")
+            b.set_raw("created_by", "current_user()")
+            b.set("skill_name", skill_name)
+            b.set_json("config_json", serialized_space, use_variant=self.settings.use_variant)
+            b.set("config_hash", config_hash)
+            b.set_array("changed_surfaces", changed_surfaces)
+            b.set("etag", etag)
+            b.set("run_id", run_id)
+            b.set("rollback_reference", rollback_reference)
+            b.set("change_summary", change_summary)
+            sql, params = b.build(self._fq_table(schema.CONFIG_SNAPSHOTS))
+            self._run(sql, params)
+
+            # 3) Post-insert verification.
+            conflicts = self._snapshot_conflicts(space_id, config_version_id, version)
+            same_id = [r for r in conflicts if r.get("config_version_id") == config_version_id]
+            other_same_version = [
+                r
+                for r in conflicts
+                if r.get("config_version_id") != config_version_id
+                and r.get("version") is not None
+                and int(r["version"]) == version
+            ]
+
+            if len(same_id) > 1:
+                # Concurrent same-key insert (the documented residual): keep one logical
+                # result. Identical rows can't be told apart for a targeted DELETE.
+                return self._dedup_result(same_id[0])
+
+            if other_same_version:
+                # A different config grabbed our version concurrently. Deterministic
+                # tie-break: the larger config_version_id yields (backs out + retries);
+                # the smaller keeps its row. Exactly one writer yields, guaranteeing
+                # forward progress.
+                other_max = max(r["config_version_id"] for r in other_same_version)
+                if config_version_id > other_max:
+                    self._delete_snapshot(config_version_id, version)
+                    continue
+
             return {
-                "config_version_id": existing.get("config_version_id"),
-                "version": int(existing["version"])
-                if existing.get("version") is not None
-                else None,
-                "config_hash": existing.get("config_hash"),
-                "etag": existing.get("etag"),
-                "deduplicated": True,
+                "config_version_id": config_version_id,
+                "version": version,
+                "config_hash": config_hash,
+                "etag": etag,
+                "deduplicated": False,
             }
 
-        version = self._next_version(space_id)
-        b = _InsertBuilder()
-        b.set("config_version_id", config_version_id)
-        b.set("space_id", space_id)
-        b.set("version", version)
-        b.set("parent_version_id", parent_version_id)
-        b.set_raw("created_at", "current_timestamp()")
-        b.set("created_by", self.user_name)
-        b.set("skill_name", skill_name)
-        b.set_json("config_json", serialized_space, use_variant=self.settings.use_variant)
-        b.set("config_hash", config_hash)
-        b.set_array("changed_surfaces", changed_surfaces)
-        b.set("etag", etag)
-        b.set("run_id", run_id)
-        b.set("rollback_reference", rollback_reference)
-        b.set("change_summary", change_summary)
-        sql, params = b.build(self._fq_table(schema.CONFIG_SNAPSHOTS))
-        self._run(sql, params)
-
-        return {
-            "config_version_id": config_version_id,
-            "version": version,
-            "config_hash": config_hash,
-            "etag": etag,
-            "deduplicated": False,
-        }
+        raise StorageContentionError(
+            f"could not allocate a unique config version for space {space_id!r} after "
+            f"{MAX_SAVE_ATTEMPTS} attempts (high write contention); please retry."
+        )
 
     # --- save_report -------------------------------------------------------
     def save_report(
@@ -231,7 +330,10 @@ class UCTableStore:
         """Persist a Markdown report to the routed table; returns ``{artifact_id}``.
 
         The caller has already validated ``artifact_type``; we resolve its table here.
-        ``idempotency_key`` (when supplied) makes retries return the same row (§6).
+        When ``idempotency_key`` is supplied the id is derived from it, so a sequential
+        retry returns the existing row (read-before-write) instead of inserting again
+        (spec §6). Without a key, each call gets a fresh random id (no dedupe intended).
+        The same concurrent-same-key residual noted on ``save_config_snapshot`` applies.
         """
         table_name = schema.ARTIFACT_TYPE_TO_REPORT_TABLE[artifact_type]
         spec = schema.TYPE_LABEL_TO_SPEC[artifact_type]
@@ -248,7 +350,7 @@ class UCTableStore:
         b.set("artifact_id", artifact_id)
         b.set("space_id", space_id)
         b.set_raw("created_at", "current_timestamp()")
-        b.set("created_by", self.user_name)
+        b.set_raw("created_by", "current_user()")
         b.set("skill_name", skill_name)
         b.set("title", title)
         b.set("content_md", content_md)

--- a/genie-code/mcp-genie-space-history/app/server/store.py
+++ b/genie-code/mcp-genie-space-history/app/server/store.py
@@ -13,12 +13,13 @@ to equal the ``SESSION_USER()`` the ``only_mine`` row filter compares against
 (spec §5/§7.1) — i.e. a user can always read back their own writes.
 
 Concurrency note (spec §6/§11): UC SQL warehouses enforce **no** PK/unique
-constraints or row locks and give us no multi-statement transaction, so
-``save_config_snapshot`` cannot make ``MAX(version)+1 → INSERT`` atomic. We use a
-bounded **optimistic-retry**: insert, then verify there is no colliding version /
-duplicate id, and on a version collision back out our row and retry. A residual
-race window remains (see ``save_config_snapshot`` + README); it is documented, not
-silently ignored.
+constraints or row locks and give us no multi-statement transaction. Config
+snapshots therefore carry **no monotonic version counter** — there is nothing to
+contend on. A save is a single ``INSERT``; snapshots are ordered and identified by
+the server-stamped ``created_at`` timestamp plus the ``config_version_id`` primary
+key. Idempotency is preserved by deriving that id deterministically from the
+idempotency key (default: ``config_hash``) and reading-before-write, so a repeated
+key resolves to the existing row instead of inserting a duplicate.
 """
 
 from __future__ import annotations
@@ -30,11 +31,7 @@ from typing import Any, Optional, Sequence
 
 from . import schema
 from .config import Settings
-from .errors import StorageContentionError
 from .sql import Param, QueryResult, SqlExec, quote_ident
-
-# Bounded optimistic-retry budget for version allocation under concurrency.
-MAX_SAVE_ATTEMPTS = 5
 
 
 def sha256_hex(text: str) -> str:
@@ -139,21 +136,6 @@ class UCTableStore:
         return f"{self._fq_schema}.{quote_ident(table_name)}"
 
     # --- helpers -----------------------------------------------------------
-    def _next_version(self, space_id: str) -> int:
-        """Monotonic per-``space_id`` version (1, 2, 3…).
-
-        Under OBO + the ``only_mine`` row filter this counts only the caller's own
-        snapshots for the space (other users' rows are invisible) — the intended
-        per-user history semantics (spec §5).
-        """
-        sql = (
-            f"SELECT COALESCE(MAX(version), 0) + 1 AS next_version "
-            f"FROM {self._fq_table(schema.CONFIG_SNAPSHOTS)} WHERE space_id = :space_id"
-        )
-        result = self._run(sql, [Param("space_id", space_id)])
-        value = result.scalar()
-        return int(value) if value is not None else 1
-
     def _find_by_id(self, spec: schema.TableSpec, id_value: str) -> Optional[dict]:
         sql = (
             f"SELECT * FROM {self._fq_table(spec.name)} "
@@ -161,46 +143,11 @@ class UCTableStore:
         )
         return self._run(sql, [Param("id", id_value)]).first()
 
-    def _snapshot_conflicts(
-        self, space_id: str, config_version_id: str, version: int
-    ) -> list[dict]:
-        """Post-insert verification: rows sharing our id OR our version for this space.
-
-        Used to detect (a) a concurrent write that landed the same idempotency-derived
-        id and (b) a concurrent write that grabbed the same ``version`` with a *different*
-        config. Runs OBO, so it sees only the caller's own rows — but concurrent writes
-        for the same (space, user) are by the same identity, hence visible here.
-        """
-        sql = (
-            f"SELECT config_version_id, version, config_hash, etag "
-            f"FROM {self._fq_table(schema.CONFIG_SNAPSHOTS)} "
-            f"WHERE space_id = :space_id AND (config_version_id = :id OR version = :version)"
-        )
-        params = [
-            Param("space_id", space_id),
-            Param("id", config_version_id),
-            Param("version", str(version), "BIGINT"),
-        ]
-        return self._run(sql, params).dicts()
-
-    def _delete_snapshot(self, config_version_id: str, version: int) -> None:
-        """Back out exactly our just-inserted row (to resolve a version collision)."""
-        sql = (
-            f"DELETE FROM {self._fq_table(schema.CONFIG_SNAPSHOTS)} "
-            f"WHERE config_version_id = :id AND version = :version"
-        )
-        self._run(
-            sql,
-            [Param("id", config_version_id), Param("version", str(version), "BIGINT")],
-        )
-
     @staticmethod
     def _dedup_result(row: dict) -> dict:
         """Shape an existing config_snapshots row as a deduplicated save result."""
-        v = row.get("version")
         return {
             "config_version_id": row.get("config_version_id"),
-            "version": int(v) if v is not None else None,
             "config_hash": row.get("config_hash"),
             "etag": row.get("etag"),
             "deduplicated": True,
@@ -221,95 +168,52 @@ class UCTableStore:
         skill_name: Optional[str] = None,
         idempotency_key: Optional[str] = None,
     ) -> dict:
-        """Persist a config version; returns ``{config_version_id, version, config_hash, etag}``.
+        """Persist a config snapshot; returns ``{config_version_id, config_hash, etag}``.
 
-        Server-computed: ``config_hash`` (sha256 of ``serialized_space``), a monotonic
-        per-space ``version``, and the logical id (deterministic from the idempotency
-        key — which defaults to ``config_hash``, so re-saving identical content is a
-        no-op that returns the existing row, spec §6).
+        Server-computed: ``config_hash`` (sha256 of ``serialized_space``) and the logical
+        id (deterministic from the idempotency key — which defaults to ``config_hash``, so
+        re-saving identical content is a no-op that returns the existing row, spec §6).
 
-        Concurrency (spec §11): UC has no unique constraints / row locks / cross-statement
-        transactions, so we run a bounded optimistic-retry — insert, then verify there is
-        no colliding version (different config, same version) or duplicate id; on a version
-        collision we back out our row and retry up to ``MAX_SAVE_ATTEMPTS``, raising a clean
-        :class:`StorageContentionError` if it cannot converge.
-
-        **Residual race (documented, not silently ignored):** two concurrent writes with the
-        *same idempotency key* can each pass read-before-write and land byte-identical rows;
-        a targeted DELETE can't distinguish them, so a transient duplicate may persist (the
-        logical result is still single + correct). Single-writer use — the normal skill
-        path — is unaffected. See the README "Concurrency" note.
+        There is **no monotonic version counter**: snapshots are ordered/identified by the
+        server-stamped ``created_at`` plus ``config_version_id`` (spec §6/§11). A save is a
+        single ``INSERT`` — no ``MAX(version)`` read, no post-insert reconciliation, nothing
+        to contend on. Idempotency is enforced by a read-before-write on the deterministic
+        id: a repeated key resolves to the existing row instead of inserting a duplicate.
         """
         config_hash = sha256_hex(serialized_space)
         idem = idempotency_key or config_hash
         config_version_id = _derive_id(f"config:{space_id}", idem)
         spec = schema.TABLE_SPECS[0]
 
-        for _attempt in range(MAX_SAVE_ATTEMPTS):
-            # 1) Idempotency read-before-write (re-checked every attempt: a concurrent
-            #    writer sharing this key may have committed since the previous try).
-            existing = self._find_by_id(spec, config_version_id)
-            if existing is not None:
-                return self._dedup_result(existing)
+        # Idempotency read-before-write: a repeated key (default: byte-identical content)
+        # resolves to the existing row rather than inserting a duplicate (spec §6).
+        existing = self._find_by_id(spec, config_version_id)
+        if existing is not None:
+            return self._dedup_result(existing)
 
-            # 2) Allocate a version and insert.
-            version = self._next_version(space_id)
-            b = _InsertBuilder()
-            b.set("config_version_id", config_version_id)
-            b.set("space_id", space_id)
-            b.set("version", version)
-            b.set("parent_version_id", parent_version_id)
-            b.set_raw("created_at", "current_timestamp()")
-            b.set_raw("created_by", "current_user()")
-            b.set("skill_name", skill_name)
-            b.set_json("config_json", serialized_space, use_variant=self.settings.use_variant)
-            b.set("config_hash", config_hash)
-            b.set_array("changed_surfaces", changed_surfaces)
-            b.set("etag", etag)
-            b.set("run_id", run_id)
-            b.set("rollback_reference", rollback_reference)
-            b.set("change_summary", change_summary)
-            sql, params = b.build(self._fq_table(schema.CONFIG_SNAPSHOTS))
-            self._run(sql, params)
+        b = _InsertBuilder()
+        b.set("config_version_id", config_version_id)
+        b.set("space_id", space_id)
+        b.set("parent_version_id", parent_version_id)
+        b.set_raw("created_at", "current_timestamp()")
+        b.set_raw("created_by", "current_user()")
+        b.set("skill_name", skill_name)
+        b.set_json("config_json", serialized_space, use_variant=self.settings.use_variant)
+        b.set("config_hash", config_hash)
+        b.set_array("changed_surfaces", changed_surfaces)
+        b.set("etag", etag)
+        b.set("run_id", run_id)
+        b.set("rollback_reference", rollback_reference)
+        b.set("change_summary", change_summary)
+        sql, params = b.build(self._fq_table(schema.CONFIG_SNAPSHOTS))
+        self._run(sql, params)
 
-            # 3) Post-insert verification.
-            conflicts = self._snapshot_conflicts(space_id, config_version_id, version)
-            same_id = [r for r in conflicts if r.get("config_version_id") == config_version_id]
-            other_same_version = [
-                r
-                for r in conflicts
-                if r.get("config_version_id") != config_version_id
-                and r.get("version") is not None
-                and int(r["version"]) == version
-            ]
-
-            if len(same_id) > 1:
-                # Concurrent same-key insert (the documented residual): keep one logical
-                # result. Identical rows can't be told apart for a targeted DELETE.
-                return self._dedup_result(same_id[0])
-
-            if other_same_version:
-                # A different config grabbed our version concurrently. Deterministic
-                # tie-break: the larger config_version_id yields (backs out + retries);
-                # the smaller keeps its row. Exactly one writer yields, guaranteeing
-                # forward progress.
-                other_max = max(r["config_version_id"] for r in other_same_version)
-                if config_version_id > other_max:
-                    self._delete_snapshot(config_version_id, version)
-                    continue
-
-            return {
-                "config_version_id": config_version_id,
-                "version": version,
-                "config_hash": config_hash,
-                "etag": etag,
-                "deduplicated": False,
-            }
-
-        raise StorageContentionError(
-            f"could not allocate a unique config version for space {space_id!r} after "
-            f"{MAX_SAVE_ATTEMPTS} attempts (high write contention); please retry."
-        )
+        return {
+            "config_version_id": config_version_id,
+            "config_hash": config_hash,
+            "etag": etag,
+            "deduplicated": False,
+        }
 
     # --- save_report -------------------------------------------------------
     def save_report(
@@ -374,10 +278,15 @@ class UCTableStore:
     ) -> list[dict]:
         """UNION across the artifact tables for a space → normalized timeline rows.
 
-        Each row: ``{id, type, version, created_at, created_by, summary, decision}``.
+        Each row: ``{id, type, version, created_at, created_by, summary, decision}``
+        (``version`` is always NULL — config snapshots no longer carry a counter).
         ``type_label`` (optional) restricts to a single artifact type; ``since``
         filters on ``created_at``. ``limit`` is a server-validated integer, so it
         is inlined safely (parameter markers are not supported in LIMIT).
+
+        Ordering is ``created_at DESC`` (newest first) with ``id`` as a stable
+        secondary tiebreaker, so pagination / ``since`` stay deterministic even when
+        two rows share a timestamp (spec §6).
         """
         specs: Sequence[schema.TableSpec]
         specs = [schema.TYPE_LABEL_TO_SPEC[type_label]] if type_label else schema.TABLE_SPECS
@@ -403,7 +312,7 @@ class UCTableStore:
 
         safe_limit = max(1, min(int(limit), 1000))
         union = "\nUNION ALL\n".join(subqueries)
-        sql = f"SELECT * FROM (\n{union}\n) ORDER BY created_at DESC LIMIT {safe_limit}"
+        sql = f"SELECT * FROM (\n{union}\n) ORDER BY created_at DESC, id ASC LIMIT {safe_limit}"
         return self._run(sql, params).dicts()
 
     # --- get_artifact ------------------------------------------------------

--- a/genie-code/mcp-genie-space-history/app/server/tools.py
+++ b/genie-code/mcp-genie-space-history/app/server/tools.py
@@ -8,8 +8,9 @@ Split into two layers so the logic is unit-testable with no live workspace:
   * :func:`register_tools` — wraps each core fn with OBO identity resolution and
     structured error handling, then registers it on the FastMCP server.
 
-All reads/writes run OBO (the calling user). ``created_by`` is stamped from
-``current_user.me()`` and ``created_at`` server-side (spec §6).
+All reads/writes run OBO (the calling user). ``created_by``/``created_at`` are
+stamped server-side via SQL ``current_user()``/``current_timestamp()`` (spec §6),
+so ``created_by`` always matches the ``SESSION_USER()`` the row filter compares.
 """
 
 from __future__ import annotations
@@ -21,6 +22,7 @@ from . import auth, schema
 from .config import Settings
 from .errors import (
     OBOScopeError,
+    StorageContentionError,
     ToolValidationError,
     error_payload,
     looks_like_scope_error,
@@ -167,9 +169,23 @@ def get_artifact_core(store: UCTableStore, *, id: str) -> dict:
 # OBO identity + structured error wrapping
 # ---------------------------------------------------------------------------
 def _build_user_store(settings: Settings) -> UCTableStore:
-    """Build an OBO-backed store for the calling user (raises OBOScopeError if no token)."""
+    """Build an OBO-backed store for the calling user.
+
+    Raises :class:`OBOScopeError` when the token is absent / OBO is disabled. A
+    token/identity-auth failure from ``current_user.me()`` (e.g. SDK ``Unauthenticated``)
+    is also re-raised as :class:`OBOScopeError` so it surfaces as a ``scope_error``
+    rather than a generic internal error (a deployed app's OBO token can default to
+    identity-only scopes — spec §5, P0 finding F-6).
+    """
     w = auth.get_user_workspace_client(obo_enabled=settings.obo_enabled)
-    me = w.current_user.me()
+    try:
+        me = w.current_user.me()
+    except OBOScopeError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        if looks_like_scope_error(exc):
+            raise OBOScopeError(f"OBO identity resolution failed: {exc}") from exc
+        raise
     user_name = me.user_name or "unknown"
     return UCTableStore(make_sql_exec(w, settings.sql_warehouse_id), settings, user_name=user_name)
 
@@ -190,6 +206,9 @@ def _run_tool(settings: Settings, tool_name: str, core: Callable[[UCTableStore],
     except ToolValidationError as exc:
         logger.info("tool=%s validation_error: %s", tool_name, exc)
         return validation_error_payload(str(exc))
+    except StorageContentionError as exc:
+        logger.warning("tool=%s contention: %s", tool_name, exc)
+        return error_payload("contention", str(exc))
     except SqlError as exc:
         if looks_like_scope_error(exc):
             logger.warning("tool=%s scope_error (sql): %s", tool_name, exc)
@@ -197,6 +216,10 @@ def _run_tool(settings: Settings, tool_name: str, core: Callable[[UCTableStore],
         logger.error("tool=%s sql_error: %s", tool_name, exc)
         return error_payload("sql_error", str(exc))
     except Exception as exc:  # noqa: BLE001 — surface anything else as a structured error
+        # Classify a token/OAuth failure as scope_error; everything else is internal.
+        if looks_like_scope_error(exc):
+            logger.warning("tool=%s scope_error (auth): %s", tool_name, exc)
+            return scope_error_payload(str(exc))
         logger.exception("tool=%s internal_error: %s", tool_name, exc)
         return error_payload("internal_error", str(exc))
 
@@ -256,14 +279,19 @@ def register_tools(mcp_server, settings: Settings) -> None:
         config_version_id: Optional[str] = None,
         skill_name: Optional[str] = None,
         redacted: bool = True,
+        redact: Optional[bool] = None,
         idempotency_key: Optional[str] = None,
     ) -> dict:
         """Persist a Markdown artifact, routed by ``artifact_type`` to its table.
 
         ``diagnose_report`` → diagnose_reports, ``query_report`` → query_reports,
         ``design_proposal`` → design_proposals, ``metric_view_ddl`` → metric_view_artifacts.
-        Unknown types are rejected. ``redacted`` defaults to true. Returns ``{artifact_id}``.
+        Unknown types are rejected. Returns ``{artifact_id}``.
+
+        Redaction defaults to true. The spec spells the flag ``redact`` (§6/§7.3); both
+        ``redact`` and ``redacted`` are accepted (``redact`` wins if both are sent).
         """
+        effective_redacted = redact if redact is not None else redacted
         return _run_tool(
             settings,
             "save_report",
@@ -278,7 +306,7 @@ def register_tools(mcp_server, settings: Settings) -> None:
                 summary=summary,
                 config_version_id=config_version_id,
                 skill_name=skill_name,
-                redacted=redacted,
+                redacted=effective_redacted,
                 idempotency_key=idempotency_key,
             ),
         )

--- a/genie-code/mcp-genie-space-history/app/server/tools.py
+++ b/genie-code/mcp-genie-space-history/app/server/tools.py
@@ -1,0 +1,317 @@
+"""The four P1 MCP tools (spec §6), plus their input validation.
+
+Split into two layers so the logic is unit-testable with no live workspace:
+
+  * ``*_core(store, ...)`` — pure functions that validate inputs against the §7
+    contracts and call :class:`~server.store.UCTableStore`. They raise
+    :class:`~server.errors.ToolValidationError` on bad input.
+  * :func:`register_tools` — wraps each core fn with OBO identity resolution and
+    structured error handling, then registers it on the FastMCP server.
+
+All reads/writes run OBO (the calling user). ``created_by`` is stamped from
+``current_user.me()`` and ``created_at`` server-side (spec §6).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Optional, Sequence
+
+from . import auth, schema
+from .config import Settings
+from .errors import (
+    OBOScopeError,
+    ToolValidationError,
+    error_payload,
+    looks_like_scope_error,
+    scope_error_payload,
+    validation_error_payload,
+)
+from .sql import SqlError, make_sql_exec
+from .store import UCTableStore
+
+logger = logging.getLogger("mcp-genie-space-history.tools")
+
+
+def _require(value: Optional[str], name: str) -> str:
+    if value is None or (isinstance(value, str) and not value.strip()):
+        raise ToolValidationError(f"`{name}` is required and must be non-empty.")
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Core tool logic (workspace-free; takes an already-built store)
+# ---------------------------------------------------------------------------
+def save_config_snapshot_core(
+    store: UCTableStore,
+    *,
+    space_id: str,
+    serialized_space: str,
+    etag: Optional[str] = None,
+    version_label: Optional[str] = None,
+    parent_config_version_id: Optional[str] = None,
+    run_id: Optional[str] = None,
+    changed_surfaces: Optional[Sequence[str]] = None,
+    change_summary: Optional[str] = None,
+    rollback_reference: Optional[str] = None,
+    skill_name: Optional[str] = None,
+    idempotency_key: Optional[str] = None,
+) -> dict:
+    _require(space_id, "space_id")
+    _require(serialized_space, "serialized_space")
+
+    # §7.1 config_snapshots has no version_label column. To avoid dropping the
+    # caller-supplied label, fold it into change_summary when no summary was given.
+    effective_summary = change_summary
+    if effective_summary is None and version_label:
+        effective_summary = version_label
+
+    result = store.save_config_snapshot(
+        space_id=space_id,
+        serialized_space=serialized_space,
+        etag=etag,
+        parent_version_id=parent_config_version_id,
+        run_id=run_id,
+        changed_surfaces=changed_surfaces,
+        change_summary=effective_summary,
+        rollback_reference=rollback_reference,
+        skill_name=skill_name,
+        idempotency_key=idempotency_key,
+    )
+    result["ok"] = True
+    return result
+
+
+def save_report_core(
+    store: UCTableStore,
+    *,
+    space_id: str,
+    artifact_type: str,
+    title: str,
+    content_md: str,
+    run_id: Optional[str] = None,
+    scores_findings: Optional[Any] = None,
+    summary: Optional[str] = None,
+    config_version_id: Optional[str] = None,
+    skill_name: Optional[str] = None,
+    redacted: bool = True,
+    idempotency_key: Optional[str] = None,
+) -> dict:
+    _require(space_id, "space_id")
+    _require(artifact_type, "artifact_type")
+    _require(title, "title")
+    _require(content_md, "content_md")
+
+    if artifact_type not in schema.ARTIFACT_TYPE_TO_REPORT_TABLE:
+        valid = ", ".join(sorted(schema.ARTIFACT_TYPE_TO_REPORT_TABLE))
+        raise ToolValidationError(
+            f"unknown artifact_type {artifact_type!r}; expected one of: {valid}"
+        )
+
+    # Derive a short summary for list_history when the caller didn't provide one.
+    effective_summary = summary
+    if effective_summary is None and content_md:
+        first_line = content_md.strip().splitlines()[0] if content_md.strip() else ""
+        effective_summary = first_line[:280] or None
+
+    result = store.save_report(
+        space_id=space_id,
+        artifact_type=artifact_type,
+        title=title,
+        content_md=content_md,
+        summary=effective_summary,
+        scores_findings=scores_findings,
+        run_id=run_id,
+        config_version_id=config_version_id,
+        skill_name=skill_name,
+        redacted=redacted,
+        idempotency_key=idempotency_key,
+    )
+    result["ok"] = True
+    return result
+
+
+def list_history_core(
+    store: UCTableStore,
+    *,
+    space_id: str,
+    artifact_type: Optional[str] = None,
+    limit: int = 50,
+    since: Optional[str] = None,
+) -> dict:
+    _require(space_id, "space_id")
+    if artifact_type is not None and artifact_type not in store.known_type_labels():
+        valid = ", ".join(sorted(store.known_type_labels()))
+        raise ToolValidationError(
+            f"unknown artifact_type {artifact_type!r}; expected one of: {valid}"
+        )
+    items = store.list_history(
+        space_id=space_id,
+        type_label=artifact_type,
+        limit=limit,
+        since=since,
+    )
+    return {"ok": True, "items": items, "count": len(items)}
+
+
+def get_artifact_core(store: UCTableStore, *, id: str) -> dict:
+    _require(id, "id")
+    found = store.get_artifact(id)
+    if found is None:
+        return {"ok": False, "error_type": "not_found", "message": f"no artifact with id {id!r}"}
+    found["ok"] = True
+    return found
+
+
+# ---------------------------------------------------------------------------
+# OBO identity + structured error wrapping
+# ---------------------------------------------------------------------------
+def _build_user_store(settings: Settings) -> UCTableStore:
+    """Build an OBO-backed store for the calling user (raises OBOScopeError if no token)."""
+    w = auth.get_user_workspace_client(obo_enabled=settings.obo_enabled)
+    me = w.current_user.me()
+    user_name = me.user_name or "unknown"
+    return UCTableStore(make_sql_exec(w, settings.sql_warehouse_id), settings, user_name=user_name)
+
+
+def _run_tool(settings: Settings, tool_name: str, core: Callable[[UCTableStore], dict]) -> dict:
+    """Resolve OBO identity, run ``core(store)``, and map errors to structured payloads.
+
+    Emits one structured log line per call (tool + outcome) for observability (spec §10).
+    """
+    try:
+        store = _build_user_store(settings)
+        result = core(store)
+        logger.info("tool=%s ok=%s", tool_name, result.get("ok", True))
+        return result
+    except OBOScopeError as exc:
+        logger.warning("tool=%s scope_error: %s", tool_name, exc)
+        return scope_error_payload(str(exc), required_scope=exc.required_scope)
+    except ToolValidationError as exc:
+        logger.info("tool=%s validation_error: %s", tool_name, exc)
+        return validation_error_payload(str(exc))
+    except SqlError as exc:
+        if looks_like_scope_error(exc):
+            logger.warning("tool=%s scope_error (sql): %s", tool_name, exc)
+            return scope_error_payload(str(exc))
+        logger.error("tool=%s sql_error: %s", tool_name, exc)
+        return error_payload("sql_error", str(exc))
+    except Exception as exc:  # noqa: BLE001 — surface anything else as a structured error
+        logger.exception("tool=%s internal_error: %s", tool_name, exc)
+        return error_payload("internal_error", str(exc))
+
+
+def register_tools(mcp_server, settings: Settings) -> None:
+    """Register the four P1 tools on the FastMCP server."""
+
+    @mcp_server.tool
+    def save_config_snapshot(
+        space_id: str,
+        serialized_space: str,
+        etag: Optional[str] = None,
+        version_label: Optional[str] = None,
+        parent_config_version_id: Optional[str] = None,
+        run_id: Optional[str] = None,
+        changed_surfaces: Optional[list[str]] = None,
+        change_summary: Optional[str] = None,
+        rollback_reference: Optional[str] = None,
+        skill_name: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
+    ) -> dict:
+        """Persist a Genie Space config version (the mandatory before/after snapshot).
+
+        The caller supplies ``serialized_space`` — the MCP never fetches it. The server
+        computes a monotonic per-space ``version``, a sha256 ``config_hash``, stores the
+        caller's ``etag`` verbatim, and sets lineage via ``parent_config_version_id``.
+        Returns ``{config_version_id, version, config_hash, etag}``. (Writes config_snapshots.)
+        """
+        return _run_tool(
+            settings,
+            "save_config_snapshot",
+            lambda store: save_config_snapshot_core(
+                store,
+                space_id=space_id,
+                serialized_space=serialized_space,
+                etag=etag,
+                version_label=version_label,
+                parent_config_version_id=parent_config_version_id,
+                run_id=run_id,
+                changed_surfaces=changed_surfaces,
+                change_summary=change_summary,
+                rollback_reference=rollback_reference,
+                skill_name=skill_name,
+                idempotency_key=idempotency_key,
+            ),
+        )
+
+    @mcp_server.tool
+    def save_report(
+        space_id: str,
+        artifact_type: str,
+        title: str,
+        content_md: str,
+        run_id: Optional[str] = None,
+        scores_findings: Optional[str] = None,
+        summary: Optional[str] = None,
+        config_version_id: Optional[str] = None,
+        skill_name: Optional[str] = None,
+        redacted: bool = True,
+        idempotency_key: Optional[str] = None,
+    ) -> dict:
+        """Persist a Markdown artifact, routed by ``artifact_type`` to its table.
+
+        ``diagnose_report`` → diagnose_reports, ``query_report`` → query_reports,
+        ``design_proposal`` → design_proposals, ``metric_view_ddl`` → metric_view_artifacts.
+        Unknown types are rejected. ``redacted`` defaults to true. Returns ``{artifact_id}``.
+        """
+        return _run_tool(
+            settings,
+            "save_report",
+            lambda store: save_report_core(
+                store,
+                space_id=space_id,
+                artifact_type=artifact_type,
+                title=title,
+                content_md=content_md,
+                run_id=run_id,
+                scores_findings=scores_findings,
+                summary=summary,
+                config_version_id=config_version_id,
+                skill_name=skill_name,
+                redacted=redacted,
+                idempotency_key=idempotency_key,
+            ),
+        )
+
+    @mcp_server.tool
+    def list_history(
+        space_id: str,
+        artifact_type: Optional[str] = None,
+        limit: int = 50,
+        since: Optional[str] = None,
+    ) -> dict:
+        """Timeline of versions/runs/reports for a Space (UNION across all artifact tables).
+
+        Returns ``{items: [{id, type, version, created_at, created_by, summary, decision}]}``.
+        ``artifact_type`` optionally restricts to one type; ``since`` filters on created_at.
+        """
+        return _run_tool(
+            settings,
+            "list_history",
+            lambda store: list_history_core(
+                store,
+                space_id=space_id,
+                artifact_type=artifact_type,
+                limit=limit,
+                since=since,
+            ),
+        )
+
+    @mcp_server.tool
+    def get_artifact(id: str) -> dict:
+        """Fetch one stored item by id (config_version_id / artifact_id / run_id).
+
+        Resolves the id across all artifact tables and returns the full record
+        (including ``config_json`` / ``content_md``).
+        """
+        return _run_tool(settings, "get_artifact", lambda store: get_artifact_core(store, id=id))

--- a/genie-code/mcp-genie-space-history/app/server/tools.py
+++ b/genie-code/mcp-genie-space-history/app/server/tools.py
@@ -22,7 +22,6 @@ from . import auth, schema
 from .config import Settings
 from .errors import (
     OBOScopeError,
-    StorageContentionError,
     ToolValidationError,
     error_payload,
     looks_like_scope_error,
@@ -206,9 +205,6 @@ def _run_tool(settings: Settings, tool_name: str, core: Callable[[UCTableStore],
     except ToolValidationError as exc:
         logger.info("tool=%s validation_error: %s", tool_name, exc)
         return validation_error_payload(str(exc))
-    except StorageContentionError as exc:
-        logger.warning("tool=%s contention: %s", tool_name, exc)
-        return error_payload("contention", str(exc))
     except SqlError as exc:
         if looks_like_scope_error(exc):
             logger.warning("tool=%s scope_error (sql): %s", tool_name, exc)
@@ -241,12 +237,13 @@ def register_tools(mcp_server, settings: Settings) -> None:
         skill_name: Optional[str] = None,
         idempotency_key: Optional[str] = None,
     ) -> dict:
-        """Persist a Genie Space config version (the mandatory before/after snapshot).
+        """Persist a Genie Space config snapshot (the mandatory before/after snapshot).
 
         The caller supplies ``serialized_space`` — the MCP never fetches it. The server
-        computes a monotonic per-space ``version``, a sha256 ``config_hash``, stores the
-        caller's ``etag`` verbatim, and sets lineage via ``parent_config_version_id``.
-        Returns ``{config_version_id, version, config_hash, etag}``. (Writes config_snapshots.)
+        computes a sha256 ``config_hash``, stores the caller's ``etag`` verbatim, and sets
+        lineage via ``parent_config_version_id``. Snapshots are ordered/identified by
+        ``created_at`` + ``config_version_id`` (no monotonic version counter). Returns
+        ``{config_version_id, config_hash, etag}``. (Writes config_snapshots.)
         """
         return _run_tool(
             settings,

--- a/genie-code/mcp-genie-space-history/app/tests/conftest.py
+++ b/genie-code/mcp-genie-space-history/app/tests/conftest.py
@@ -49,6 +49,14 @@ class InMemoryBackend:
         self.rows: dict[str, dict[str, dict]] = defaultdict(dict)
         # configurable canned result for list_history queries
         self.list_result = QueryResult([], [])
+        # Concurrency simulation knobs for the config_snapshots verification query:
+        #   pending_conflict    — a phantom row returned ONCE then cleared (a concurrent
+        #                         writer that landed between our MAX(version) read + insert)
+        #   persistent_conflict — a phantom row returned on EVERY verification (never converges)
+        #   inject_dup_id       — return our own row twice ONCE (same-key concurrent insert)
+        self.pending_conflict: Optional[dict] = None
+        self.persistent_conflict: Optional[dict] = None
+        self.inject_dup_id: bool = False
 
     # --- call recording helpers -------------------------------------------
     def inserts_into(self, table_name: str) -> list[tuple[str, list[Param]]]:
@@ -60,6 +68,9 @@ class InMemoryBackend:
 
     def all_inserts(self) -> list[tuple[str, list[Param]]]:
         return [(sql, params) for sql, params in self.calls if sql.lstrip().startswith("INSERT")]
+
+    def deletes(self) -> list[tuple[str, list[Param]]]:
+        return [(sql, params) for sql, params in self.calls if sql.lstrip().startswith("DELETE")]
 
     # --- the SqlExec interface --------------------------------------------
     def __call__(self, sql: str, parameters: Optional[Sequence[Param]] = None) -> QueryResult:
@@ -75,6 +86,9 @@ class InMemoryBackend:
                 if row.get("space_id") == space_id and row.get("version") is not None
             ]
             return QueryResult(["next_version"], [[(max(versions) + 1) if versions else 1]])
+
+        if "config_version_id = :id OR version = :version" in sql:  # _snapshot_conflicts
+            return self._conflicts(params)
 
         if "ORDER BY created_at DESC LIMIT" in sql:  # list_history
             return self.list_result
@@ -96,7 +110,43 @@ class InMemoryBackend:
                 self.rows[table][key] = row
             return QueryResult([], [])
 
+        if stripped.startswith("DELETE"):  # _delete_snapshot
+            table = _table_of(sql) or ""
+            id_value = param_value(params, "id")
+            version = param_value(params, "version")
+            row = self.rows.get(table, {}).get(id_value or "")
+            if id_value is not None and row is not None and str(row.get("version")) == str(version):
+                del self.rows[table][id_value]
+            return QueryResult([], [])
+
         return QueryResult([], [])
+
+    _CONFLICT_COLS = ["config_version_id", "version", "config_hash", "etag"]
+
+    def _conflicts(self, params: Sequence[Param]) -> QueryResult:
+        space_id = param_value(params, "space_id")
+        id_value = param_value(params, "id")
+        version = param_value(params, "version")
+        matched: list[dict] = [
+            r
+            for r in self.rows[schema.CONFIG_SNAPSHOTS].values()
+            if r.get("space_id") == space_id
+            and (r.get("config_version_id") == id_value or str(r.get("version")) == str(version))
+        ]
+        out = [{c: r.get(c) for c in self._CONFLICT_COLS} for r in matched]
+
+        if self.inject_dup_id:
+            ours = next((r for r in out if r["config_version_id"] == id_value), None)
+            if ours is not None:
+                out.append(dict(ours))
+            self.inject_dup_id = False
+        if self.pending_conflict is not None:
+            out.append({c: self.pending_conflict.get(c) for c in self._CONFLICT_COLS})
+            self.pending_conflict = None
+        if self.persistent_conflict is not None:
+            out.append({c: self.persistent_conflict.get(c) for c in self._CONFLICT_COLS})
+
+        return QueryResult(self._CONFLICT_COLS, [[r[c] for c in self._CONFLICT_COLS] for r in out])
 
 
 @pytest.fixture

--- a/genie-code/mcp-genie-space-history/app/tests/conftest.py
+++ b/genie-code/mcp-genie-space-history/app/tests/conftest.py
@@ -1,0 +1,120 @@
+"""Test fixtures — a fully in-memory SQL backend so tests need NO live workspace.
+
+:class:`InMemoryBackend` is a fake :data:`~server.sql.SqlExec`: it records every
+statement + bound params, simulates ``INSERT`` (stores the row keyed by its logical
+PK), ``SELECT ... WHERE pk = :id LIMIT 1`` (the store's dedupe / get_artifact lookup),
+and ``COALESCE(MAX(version)) + 1`` (monotonic versioning). This lets the store and
+tool logic be exercised end-to-end against real SQL strings + bound parameters,
+without the Databricks SDK ever making a network call.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from typing import Optional, Sequence
+
+import pytest
+
+from server import schema
+from server.config import Settings
+from server.sql import Param, QueryResult
+from server.store import UCTableStore
+
+# `cat`.`schema`.`table` — capture the table name (3rd backtick-quoted part).
+_TABLE_RE = re.compile(r"`[^`]+`\.`[^`]+`\.`([^`]+)`")
+
+
+def param_value(params: Sequence[Param], name: str) -> Optional[str]:
+    for p in params:
+        if p.name == name:
+            return p.value
+    return None
+
+
+def _table_of(sql: str) -> Optional[str]:
+    m = _TABLE_RE.search(sql)
+    return m.group(1) if m else None
+
+
+_ID_COLUMN = {spec.name: spec.id_column for spec in schema.TABLE_SPECS}
+
+
+class InMemoryBackend:
+    """A stateful fake SqlExec simulating the genie_space_history tables."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, list[Param]]] = []
+        # table_name -> id_value -> row dict (col -> value)
+        self.rows: dict[str, dict[str, dict]] = defaultdict(dict)
+        # configurable canned result for list_history queries
+        self.list_result = QueryResult([], [])
+
+    # --- call recording helpers -------------------------------------------
+    def inserts_into(self, table_name: str) -> list[tuple[str, list[Param]]]:
+        return [
+            (sql, params)
+            for sql, params in self.calls
+            if sql.lstrip().startswith("INSERT") and _table_of(sql) == table_name
+        ]
+
+    def all_inserts(self) -> list[tuple[str, list[Param]]]:
+        return [(sql, params) for sql, params in self.calls if sql.lstrip().startswith("INSERT")]
+
+    # --- the SqlExec interface --------------------------------------------
+    def __call__(self, sql: str, parameters: Optional[Sequence[Param]] = None) -> QueryResult:
+        params = list(parameters or [])
+        self.calls.append((sql, params))
+        stripped = sql.lstrip()
+
+        if "COALESCE(MAX(version)" in sql:
+            space_id = param_value(params, "space_id")
+            versions = [
+                int(row["version"])
+                for row in self.rows[schema.CONFIG_SNAPSHOTS].values()
+                if row.get("space_id") == space_id and row.get("version") is not None
+            ]
+            return QueryResult(["next_version"], [[(max(versions) + 1) if versions else 1]])
+
+        if "ORDER BY created_at DESC LIMIT" in sql:  # list_history
+            return self.list_result
+
+        if stripped.startswith("SELECT *") and "LIMIT 1" in sql:  # _find_by_id / get_artifact
+            table = _table_of(sql)
+            id_value = param_value(params, "id")
+            row = self.rows.get(table or "", {}).get(id_value or "")
+            if row is None:
+                return QueryResult([], [])
+            return QueryResult(list(row.keys()), [list(row.values())])
+
+        if stripped.startswith("INSERT"):
+            table = _table_of(sql) or ""
+            row = {p.name: p.value for p in params}
+            id_col = _ID_COLUMN.get(table)
+            key = row.get(id_col) if id_col else None
+            if key is not None:
+                self.rows[table][key] = row
+            return QueryResult([], [])
+
+        return QueryResult([], [])
+
+
+@pytest.fixture
+def settings() -> Settings:
+    return Settings(
+        history_catalog="testcat",
+        history_owner_group="owner_group",
+        history_grantee="grantee_group",
+        sql_warehouse_id="wh123",
+        use_variant=False,
+    )
+
+
+@pytest.fixture
+def backend() -> InMemoryBackend:
+    return InMemoryBackend()
+
+
+@pytest.fixture
+def store(backend: InMemoryBackend, settings: Settings) -> UCTableStore:
+    return UCTableStore(backend, settings, user_name="alice@example.com")

--- a/genie-code/mcp-genie-space-history/app/tests/conftest.py
+++ b/genie-code/mcp-genie-space-history/app/tests/conftest.py
@@ -2,10 +2,10 @@
 
 :class:`InMemoryBackend` is a fake :data:`~server.sql.SqlExec`: it records every
 statement + bound params, simulates ``INSERT`` (stores the row keyed by its logical
-PK), ``SELECT ... WHERE pk = :id LIMIT 1`` (the store's dedupe / get_artifact lookup),
-and ``COALESCE(MAX(version)) + 1`` (monotonic versioning). This lets the store and
-tool logic be exercised end-to-end against real SQL strings + bound parameters,
-without the Databricks SDK ever making a network call.
+PK) and ``SELECT ... WHERE pk = :id LIMIT 1`` (the store's idempotency dedupe /
+get_artifact lookup). This lets the store and tool logic be exercised end-to-end
+against real SQL strings + bound parameters, without the Databricks SDK ever making
+a network call.
 """
 
 from __future__ import annotations
@@ -49,14 +49,6 @@ class InMemoryBackend:
         self.rows: dict[str, dict[str, dict]] = defaultdict(dict)
         # configurable canned result for list_history queries
         self.list_result = QueryResult([], [])
-        # Concurrency simulation knobs for the config_snapshots verification query:
-        #   pending_conflict    — a phantom row returned ONCE then cleared (a concurrent
-        #                         writer that landed between our MAX(version) read + insert)
-        #   persistent_conflict — a phantom row returned on EVERY verification (never converges)
-        #   inject_dup_id       — return our own row twice ONCE (same-key concurrent insert)
-        self.pending_conflict: Optional[dict] = None
-        self.persistent_conflict: Optional[dict] = None
-        self.inject_dup_id: bool = False
 
     # --- call recording helpers -------------------------------------------
     def inserts_into(self, table_name: str) -> list[tuple[str, list[Param]]]:
@@ -69,28 +61,13 @@ class InMemoryBackend:
     def all_inserts(self) -> list[tuple[str, list[Param]]]:
         return [(sql, params) for sql, params in self.calls if sql.lstrip().startswith("INSERT")]
 
-    def deletes(self) -> list[tuple[str, list[Param]]]:
-        return [(sql, params) for sql, params in self.calls if sql.lstrip().startswith("DELETE")]
-
     # --- the SqlExec interface --------------------------------------------
     def __call__(self, sql: str, parameters: Optional[Sequence[Param]] = None) -> QueryResult:
         params = list(parameters or [])
         self.calls.append((sql, params))
         stripped = sql.lstrip()
 
-        if "COALESCE(MAX(version)" in sql:
-            space_id = param_value(params, "space_id")
-            versions = [
-                int(row["version"])
-                for row in self.rows[schema.CONFIG_SNAPSHOTS].values()
-                if row.get("space_id") == space_id and row.get("version") is not None
-            ]
-            return QueryResult(["next_version"], [[(max(versions) + 1) if versions else 1]])
-
-        if "config_version_id = :id OR version = :version" in sql:  # _snapshot_conflicts
-            return self._conflicts(params)
-
-        if "ORDER BY created_at DESC LIMIT" in sql:  # list_history
+        if "ORDER BY created_at DESC" in sql:  # list_history
             return self.list_result
 
         if stripped.startswith("SELECT *") and "LIMIT 1" in sql:  # _find_by_id / get_artifact
@@ -110,43 +87,7 @@ class InMemoryBackend:
                 self.rows[table][key] = row
             return QueryResult([], [])
 
-        if stripped.startswith("DELETE"):  # _delete_snapshot
-            table = _table_of(sql) or ""
-            id_value = param_value(params, "id")
-            version = param_value(params, "version")
-            row = self.rows.get(table, {}).get(id_value or "")
-            if id_value is not None and row is not None and str(row.get("version")) == str(version):
-                del self.rows[table][id_value]
-            return QueryResult([], [])
-
         return QueryResult([], [])
-
-    _CONFLICT_COLS = ["config_version_id", "version", "config_hash", "etag"]
-
-    def _conflicts(self, params: Sequence[Param]) -> QueryResult:
-        space_id = param_value(params, "space_id")
-        id_value = param_value(params, "id")
-        version = param_value(params, "version")
-        matched: list[dict] = [
-            r
-            for r in self.rows[schema.CONFIG_SNAPSHOTS].values()
-            if r.get("space_id") == space_id
-            and (r.get("config_version_id") == id_value or str(r.get("version")) == str(version))
-        ]
-        out = [{c: r.get(c) for c in self._CONFLICT_COLS} for r in matched]
-
-        if self.inject_dup_id:
-            ours = next((r for r in out if r["config_version_id"] == id_value), None)
-            if ours is not None:
-                out.append(dict(ours))
-            self.inject_dup_id = False
-        if self.pending_conflict is not None:
-            out.append({c: self.pending_conflict.get(c) for c in self._CONFLICT_COLS})
-            self.pending_conflict = None
-        if self.persistent_conflict is not None:
-            out.append({c: self.persistent_conflict.get(c) for c in self._CONFLICT_COLS})
-
-        return QueryResult(self._CONFLICT_COLS, [[r[c] for c in self._CONFLICT_COLS] for r in out])
 
 
 @pytest.fixture

--- a/genie-code/mcp-genie-space-history/app/tests/test_config_snapshots.py
+++ b/genie-code/mcp-genie-space-history/app/tests/test_config_snapshots.py
@@ -1,4 +1,8 @@
-"""save_config_snapshot: version monotonicity, config_hash, lineage, idempotency."""
+"""save_config_snapshot: single-INSERT persistence, config_hash, lineage, idempotency.
+
+There is no monotonic version counter: each save is one INSERT, and snapshots are
+ordered/identified by ``created_at`` + ``config_version_id`` (B1 resolution).
+"""
 
 from __future__ import annotations
 
@@ -7,9 +11,7 @@ import hashlib
 import pytest
 
 from server import schema
-from server import store as store_module
-from server.errors import StorageContentionError, ToolValidationError
-from server.store import MAX_SAVE_ATTEMPTS
+from server.errors import ToolValidationError
 from server.tools import save_config_snapshot_core
 
 from .conftest import param_value
@@ -19,21 +21,36 @@ def _config_inserts(backend):
     return backend.inserts_into(schema.CONFIG_SNAPSHOTS)
 
 
-def _cvid(space_id: str, serialized: str, idempotency_key: str | None = None) -> str:
-    """Recompute the deterministic config_version_id the store will derive."""
-    idem = idempotency_key or store_module.sha256_hex(serialized)
-    return store_module._derive_id(f"config:{space_id}", idem)
+def test_save_returns_no_version_field(store):
+    result = save_config_snapshot_core(store, space_id="s1", serialized_space='{"v":1}')
+    # The monotonic version concept is gone entirely — the result no longer carries it.
+    assert "version" not in result
+    assert result["ok"] is True
+    assert result["deduplicated"] is False
 
 
-def test_version_is_monotonic_per_space(store, backend):
+def test_save_is_a_single_insert_with_no_version_machinery(store, backend):
+    save_config_snapshot_core(store, space_id="s1", serialized_space='{"v":1}')
+    # One INSERT, no MAX(version) read, no post-insert reconciliation query, no DELETE.
+    assert len(_config_inserts(backend)) == 1
+    assert not any("MAX(version)" in sql for sql, _ in backend.calls)
+    assert not any(sql.lstrip().startswith("DELETE") for sql, _ in backend.calls)
+    # No version column is bound on the INSERT.
+    _sql, params = _config_inserts(backend)[-1]
+    assert param_value(params, "version") is None
+
+
+def test_two_rapid_snapshots_persist_as_distinct_rows(store, backend):
+    """Two successive snapshots for the same space (distinct content) both persist."""
     r1 = save_config_snapshot_core(store, space_id="s1", serialized_space='{"v":1}')
     r2 = save_config_snapshot_core(store, space_id="s1", serialized_space='{"v":2}')
-    r3 = save_config_snapshot_core(store, space_id="s1", serialized_space='{"v":3}')
-    assert [r1["version"], r2["version"], r3["version"]] == [1, 2, 3]
 
-    # A different space restarts its own counter at 1.
-    other = save_config_snapshot_core(store, space_id="s2", serialized_space='{"v":1}')
-    assert other["version"] == 1
+    assert r1["deduplicated"] is False
+    assert r2["deduplicated"] is False
+    assert r1["config_version_id"] != r2["config_version_id"]
+    # Each save is exactly one INSERT; both rows survive as distinct rows.
+    assert len(_config_inserts(backend)) == 2
+    assert len(backend.rows[schema.CONFIG_SNAPSHOTS]) == 2
 
 
 def test_config_hash_is_sha256_of_serialized_space(store):
@@ -43,7 +60,8 @@ def test_config_hash_is_sha256_of_serialized_space(store):
     assert result["config_hash"] == expected
 
 
-def test_lineage_parent_version_id_is_persisted(store, backend):
+def test_lineage_parent_reference_is_keyed_on_config_version_id(store, backend):
+    """Lineage points at the artifact id (config_version_id), never a version number."""
     r1 = save_config_snapshot_core(store, space_id="s1", serialized_space='{"v":1}')
     save_config_snapshot_core(
         store,
@@ -67,7 +85,8 @@ def test_created_by_is_server_side_current_user(store, backend):
 def test_created_at_is_server_side(store, backend):
     save_config_snapshot_core(store, space_id="s1", serialized_space='{"v":1}')
     sql, params = _config_inserts(backend)[-1]
-    # created_at uses current_timestamp() (no bound param) so it's server-stamped.
+    # created_at uses current_timestamp() (no bound param) so it's server-stamped — it is
+    # the ordering/identity key now that there is no version counter.
     assert "current_timestamp()" in sql
     assert param_value(params, "created_at") is None
 
@@ -100,8 +119,7 @@ def test_idempotency_default_dedupes_identical_config(store, backend):
 
     assert r2["deduplicated"] is True
     assert r2["config_version_id"] == r1["config_version_id"]
-    assert r2["version"] == r1["version"]
-    # The retry must NOT insert a second row.
+    # The repeat must NOT insert a second row.
     assert len(_config_inserts(backend)) == 1
 
 
@@ -143,80 +161,3 @@ def test_missing_required_inputs_rejected(store):
         save_config_snapshot_core(store, space_id="", serialized_space='{"v":1}')
     with pytest.raises(ToolValidationError):
         save_config_snapshot_core(store, space_id="s1", serialized_space="")
-
-
-# --- B1: version-allocation race / optimistic-retry ------------------------
-def test_version_collision_backs_out_and_retries(store, backend):
-    """A concurrent different-config writer grabs our version; the larger-id writer
-    backs out its row (DELETE) and retries, converging on a unique version."""
-    serialized = '{"v":1}'
-    cvid = _cvid("s1", serialized)
-    # Phantom shares version 1 but has a SMALLER id -> our writer yields (deletes+retries).
-    backend.pending_conflict = {
-        "config_version_id": cvid[:-1],
-        "version": 1,
-        "config_hash": "other-config",
-        "etag": None,
-    }
-
-    result = save_config_snapshot_core(store, space_id="s1", serialized_space=serialized)
-
-    assert result["deduplicated"] is False
-    assert result["config_version_id"] == cvid
-    assert result["version"] == 1  # recomputed after backing out
-    assert len(backend.deletes()) == 1  # backed out exactly once
-    assert len(_config_inserts(backend)) == 2  # first attempt + retry
-    assert len(backend.rows[schema.CONFIG_SNAPSHOTS]) == 1  # one row survives
-
-
-def test_version_collision_winner_keeps_its_row(store, backend):
-    """When our id is the smaller one in a collision, we keep our row (no retry/delete)."""
-    serialized = '{"v":1}'
-    cvid = _cvid("s1", serialized)
-    backend.pending_conflict = {
-        "config_version_id": cvid + "0",  # larger id -> the OTHER writer yields
-        "version": 1,
-        "config_hash": "other-config",
-        "etag": None,
-    }
-
-    result = save_config_snapshot_core(store, space_id="s1", serialized_space=serialized)
-
-    assert result["deduplicated"] is False
-    assert result["version"] == 1
-    assert backend.deletes() == []
-    assert len(_config_inserts(backend)) == 1
-
-
-def test_unresolvable_contention_raises_clean_error(store, backend):
-    """If every attempt collides (persistent contention), surface a clean error rather
-    than leaving a colliding row."""
-    serialized = '{"v":1}'
-    cvid = _cvid("s1", serialized)
-    backend.persistent_conflict = {
-        "config_version_id": cvid[:-1],  # always smaller -> we always yield
-        "version": 1,
-        "config_hash": "other-config",
-        "etag": None,
-    }
-
-    with pytest.raises(StorageContentionError):
-        save_config_snapshot_core(store, space_id="s1", serialized_space=serialized)
-
-    assert len(_config_inserts(backend)) == MAX_SAVE_ATTEMPTS
-    assert len(backend.deletes()) == MAX_SAVE_ATTEMPTS
-    assert backend.rows[schema.CONFIG_SNAPSHOTS] == {}  # nothing left behind
-
-
-def test_concurrent_same_key_returns_single_logical_result(store, backend):
-    """A concurrent insert sharing the idempotency key is detected post-insert and
-    collapsed to one logical (deduplicated) result (documented residual)."""
-    serialized = '{"v":1}'
-    cvid = _cvid("s1", serialized)
-    backend.inject_dup_id = True
-
-    result = save_config_snapshot_core(store, space_id="s1", serialized_space=serialized)
-
-    assert result["deduplicated"] is True
-    assert result["config_version_id"] == cvid
-    assert len(backend.deletes()) == 0  # identical rows can't be safely targeted

--- a/genie-code/mcp-genie-space-history/app/tests/test_config_snapshots.py
+++ b/genie-code/mcp-genie-space-history/app/tests/test_config_snapshots.py
@@ -1,0 +1,134 @@
+"""save_config_snapshot: version monotonicity, config_hash, lineage, idempotency."""
+
+from __future__ import annotations
+
+import hashlib
+
+import pytest
+
+from server import schema
+from server.errors import ToolValidationError
+from server.tools import save_config_snapshot_core
+
+from .conftest import param_value
+
+
+def _config_inserts(backend):
+    return backend.inserts_into(schema.CONFIG_SNAPSHOTS)
+
+
+def test_version_is_monotonic_per_space(store, backend):
+    r1 = save_config_snapshot_core(store, space_id="s1", serialized_space='{"v":1}')
+    r2 = save_config_snapshot_core(store, space_id="s1", serialized_space='{"v":2}')
+    r3 = save_config_snapshot_core(store, space_id="s1", serialized_space='{"v":3}')
+    assert [r1["version"], r2["version"], r3["version"]] == [1, 2, 3]
+
+    # A different space restarts its own counter at 1.
+    other = save_config_snapshot_core(store, space_id="s2", serialized_space='{"v":1}')
+    assert other["version"] == 1
+
+
+def test_config_hash_is_sha256_of_serialized_space(store):
+    serialized = '{"data_sources":{"tables":[]}}'
+    result = save_config_snapshot_core(store, space_id="s1", serialized_space=serialized)
+    expected = hashlib.sha256(serialized.encode("utf-8")).hexdigest()
+    assert result["config_hash"] == expected
+
+
+def test_lineage_parent_version_id_is_persisted(store, backend):
+    r1 = save_config_snapshot_core(store, space_id="s1", serialized_space='{"v":1}')
+    save_config_snapshot_core(
+        store,
+        space_id="s1",
+        serialized_space='{"v":2}',
+        parent_config_version_id=r1["config_version_id"],
+    )
+    _sql, params = _config_inserts(backend)[-1]
+    assert param_value(params, "parent_version_id") == r1["config_version_id"]
+
+
+def test_created_by_is_stamped_from_user(store, backend):
+    save_config_snapshot_core(store, space_id="s1", serialized_space='{"v":1}')
+    _sql, params = _config_inserts(backend)[-1]
+    assert param_value(params, "created_by") == "alice@example.com"
+
+
+def test_created_at_is_server_side(store, backend):
+    save_config_snapshot_core(store, space_id="s1", serialized_space='{"v":1}')
+    sql, params = _config_inserts(backend)[-1]
+    # created_at uses current_timestamp() (no bound param) so it's server-stamped.
+    assert "current_timestamp()" in sql
+    assert param_value(params, "created_at") is None
+
+
+def test_etag_stored_verbatim_and_returned(store, backend):
+    result = save_config_snapshot_core(
+        store, space_id="s1", serialized_space='{"v":1}', etag="etag-abc-123"
+    )
+    assert result["etag"] == "etag-abc-123"
+    _sql, params = _config_inserts(backend)[-1]
+    assert param_value(params, "etag") == "etag-abc-123"
+
+
+def test_changed_surfaces_bound_as_json_array(store, backend):
+    save_config_snapshot_core(
+        store,
+        space_id="s1",
+        serialized_space='{"v":1}',
+        changed_surfaces=["join_specs", "column_configs"],
+    )
+    sql, params = _config_inserts(backend)[-1]
+    assert "from_json(:changed_surfaces, 'ARRAY<STRING>')" in sql
+    assert param_value(params, "changed_surfaces") == '["join_specs", "column_configs"]'
+
+
+def test_idempotency_default_dedupes_identical_config(store, backend):
+    serialized = '{"v":1}'
+    r1 = save_config_snapshot_core(store, space_id="s1", serialized_space=serialized)
+    r2 = save_config_snapshot_core(store, space_id="s1", serialized_space=serialized)
+
+    assert r2["deduplicated"] is True
+    assert r2["config_version_id"] == r1["config_version_id"]
+    assert r2["version"] == r1["version"]
+    # The retry must NOT insert a second row.
+    assert len(_config_inserts(backend)) == 1
+
+
+def test_explicit_idempotency_key_dedupes(store, backend):
+    # Different content but the same caller-supplied key => same row (retry semantics).
+    r1 = save_config_snapshot_core(
+        store, space_id="s1", serialized_space='{"v":1}', idempotency_key="retry-key"
+    )
+    r2 = save_config_snapshot_core(
+        store, space_id="s1", serialized_space='{"v":2}', idempotency_key="retry-key"
+    )
+    assert r2["deduplicated"] is True
+    assert r2["config_version_id"] == r1["config_version_id"]
+    assert len(_config_inserts(backend)) == 1
+
+
+def test_version_label_folds_into_change_summary_when_absent(store, backend):
+    save_config_snapshot_core(
+        store, space_id="s1", serialized_space='{"v":1}', version_label="baseline-v1"
+    )
+    _sql, params = _config_inserts(backend)[-1]
+    assert param_value(params, "change_summary") == "baseline-v1"
+
+
+def test_explicit_change_summary_takes_precedence_over_version_label(store, backend):
+    save_config_snapshot_core(
+        store,
+        space_id="s1",
+        serialized_space='{"v":1}',
+        version_label="baseline-v1",
+        change_summary="real summary",
+    )
+    _sql, params = _config_inserts(backend)[-1]
+    assert param_value(params, "change_summary") == "real summary"
+
+
+def test_missing_required_inputs_rejected(store):
+    with pytest.raises(ToolValidationError):
+        save_config_snapshot_core(store, space_id="", serialized_space='{"v":1}')
+    with pytest.raises(ToolValidationError):
+        save_config_snapshot_core(store, space_id="s1", serialized_space="")

--- a/genie-code/mcp-genie-space-history/app/tests/test_config_snapshots.py
+++ b/genie-code/mcp-genie-space-history/app/tests/test_config_snapshots.py
@@ -7,7 +7,9 @@ import hashlib
 import pytest
 
 from server import schema
-from server.errors import ToolValidationError
+from server import store as store_module
+from server.errors import StorageContentionError, ToolValidationError
+from server.store import MAX_SAVE_ATTEMPTS
 from server.tools import save_config_snapshot_core
 
 from .conftest import param_value
@@ -15,6 +17,12 @@ from .conftest import param_value
 
 def _config_inserts(backend):
     return backend.inserts_into(schema.CONFIG_SNAPSHOTS)
+
+
+def _cvid(space_id: str, serialized: str, idempotency_key: str | None = None) -> str:
+    """Recompute the deterministic config_version_id the store will derive."""
+    idem = idempotency_key or store_module.sha256_hex(serialized)
+    return store_module._derive_id(f"config:{space_id}", idem)
 
 
 def test_version_is_monotonic_per_space(store, backend):
@@ -47,10 +55,13 @@ def test_lineage_parent_version_id_is_persisted(store, backend):
     assert param_value(params, "parent_version_id") == r1["config_version_id"]
 
 
-def test_created_by_is_stamped_from_user(store, backend):
+def test_created_by_is_server_side_current_user(store, backend):
     save_config_snapshot_core(store, space_id="s1", serialized_space='{"v":1}')
-    _sql, params = _config_inserts(backend)[-1]
-    assert param_value(params, "created_by") == "alice@example.com"
+    sql, params = _config_inserts(backend)[-1]
+    # created_by uses current_user() (no bound param) so it always matches SESSION_USER()
+    # used by the only_mine row filter.
+    assert "current_user()" in sql
+    assert param_value(params, "created_by") is None
 
 
 def test_created_at_is_server_side(store, backend):
@@ -132,3 +143,80 @@ def test_missing_required_inputs_rejected(store):
         save_config_snapshot_core(store, space_id="", serialized_space='{"v":1}')
     with pytest.raises(ToolValidationError):
         save_config_snapshot_core(store, space_id="s1", serialized_space="")
+
+
+# --- B1: version-allocation race / optimistic-retry ------------------------
+def test_version_collision_backs_out_and_retries(store, backend):
+    """A concurrent different-config writer grabs our version; the larger-id writer
+    backs out its row (DELETE) and retries, converging on a unique version."""
+    serialized = '{"v":1}'
+    cvid = _cvid("s1", serialized)
+    # Phantom shares version 1 but has a SMALLER id -> our writer yields (deletes+retries).
+    backend.pending_conflict = {
+        "config_version_id": cvid[:-1],
+        "version": 1,
+        "config_hash": "other-config",
+        "etag": None,
+    }
+
+    result = save_config_snapshot_core(store, space_id="s1", serialized_space=serialized)
+
+    assert result["deduplicated"] is False
+    assert result["config_version_id"] == cvid
+    assert result["version"] == 1  # recomputed after backing out
+    assert len(backend.deletes()) == 1  # backed out exactly once
+    assert len(_config_inserts(backend)) == 2  # first attempt + retry
+    assert len(backend.rows[schema.CONFIG_SNAPSHOTS]) == 1  # one row survives
+
+
+def test_version_collision_winner_keeps_its_row(store, backend):
+    """When our id is the smaller one in a collision, we keep our row (no retry/delete)."""
+    serialized = '{"v":1}'
+    cvid = _cvid("s1", serialized)
+    backend.pending_conflict = {
+        "config_version_id": cvid + "0",  # larger id -> the OTHER writer yields
+        "version": 1,
+        "config_hash": "other-config",
+        "etag": None,
+    }
+
+    result = save_config_snapshot_core(store, space_id="s1", serialized_space=serialized)
+
+    assert result["deduplicated"] is False
+    assert result["version"] == 1
+    assert backend.deletes() == []
+    assert len(_config_inserts(backend)) == 1
+
+
+def test_unresolvable_contention_raises_clean_error(store, backend):
+    """If every attempt collides (persistent contention), surface a clean error rather
+    than leaving a colliding row."""
+    serialized = '{"v":1}'
+    cvid = _cvid("s1", serialized)
+    backend.persistent_conflict = {
+        "config_version_id": cvid[:-1],  # always smaller -> we always yield
+        "version": 1,
+        "config_hash": "other-config",
+        "etag": None,
+    }
+
+    with pytest.raises(StorageContentionError):
+        save_config_snapshot_core(store, space_id="s1", serialized_space=serialized)
+
+    assert len(_config_inserts(backend)) == MAX_SAVE_ATTEMPTS
+    assert len(backend.deletes()) == MAX_SAVE_ATTEMPTS
+    assert backend.rows[schema.CONFIG_SNAPSHOTS] == {}  # nothing left behind
+
+
+def test_concurrent_same_key_returns_single_logical_result(store, backend):
+    """A concurrent insert sharing the idempotency key is detected post-insert and
+    collapsed to one logical (deduplicated) result (documented residual)."""
+    serialized = '{"v":1}'
+    cvid = _cvid("s1", serialized)
+    backend.inject_dup_id = True
+
+    result = save_config_snapshot_core(store, space_id="s1", serialized_space=serialized)
+
+    assert result["deduplicated"] is True
+    assert result["config_version_id"] == cvid
+    assert len(backend.deletes()) == 0  # identical rows can't be safely targeted

--- a/genie-code/mcp-genie-space-history/app/tests/test_list_get.py
+++ b/genie-code/mcp-genie-space-history/app/tests/test_list_get.py
@@ -1,0 +1,101 @@
+"""list_history (UNION + filter) and get_artifact (id resolution across tables)."""
+
+from __future__ import annotations
+
+import pytest
+
+from server import schema
+from server.errors import ToolValidationError
+from server.sql import QueryResult
+from server.tools import (
+    get_artifact_core,
+    list_history_core,
+    save_config_snapshot_core,
+    save_report_core,
+)
+
+from .conftest import param_value
+
+_LIST_COLUMNS = ["id", "type", "version", "created_at", "created_by", "summary", "decision"]
+
+
+def test_list_history_unions_all_tables_and_returns_items(store, backend):
+    backend.list_result = QueryResult(
+        _LIST_COLUMNS,
+        [["abc", "config_snapshot", 1, "2026-01-01T00:00:00Z", "alice", "v1", None]],
+    )
+    result = list_history_core(store, space_id="s1")
+
+    assert result["ok"] is True
+    assert result["count"] == 1
+    assert result["items"] == backend.list_result.dicts()
+
+    list_sql, params = backend.calls[-1]
+    # Every artifact table participates in the UNION when no filter is given.
+    for table_name in schema.ALL_TABLE_NAMES:
+        assert table_name in list_sql
+    assert param_value(params, "space_id") == "s1"
+
+
+def test_list_history_filter_restricts_to_one_table(store, backend):
+    backend.list_result = QueryResult(_LIST_COLUMNS, [])
+    list_history_core(store, space_id="s1", artifact_type="diagnose_report")
+    list_sql, _params = backend.calls[-1]
+    assert schema.DIAGNOSE_REPORTS in list_sql
+    assert schema.CONFIG_SNAPSHOTS not in list_sql
+    assert schema.QUERY_REPORTS not in list_sql
+
+
+def test_list_history_since_binds_param(store, backend):
+    backend.list_result = QueryResult(_LIST_COLUMNS, [])
+    list_history_core(store, space_id="s1", since="2026-01-01T00:00:00Z")
+    list_sql, params = backend.calls[-1]
+    assert "created_at >= :since" in list_sql
+    assert param_value(params, "since") == "2026-01-01T00:00:00Z"
+
+
+def test_list_history_limit_is_clamped_and_inlined(store, backend):
+    backend.list_result = QueryResult(_LIST_COLUMNS, [])
+    list_history_core(store, space_id="s1", limit=99999)
+    list_sql, _params = backend.calls[-1]
+    assert "LIMIT 1000" in list_sql  # clamped to the 1000 ceiling
+
+
+def test_list_history_unknown_artifact_type_rejected(store):
+    with pytest.raises(ToolValidationError):
+        list_history_core(store, space_id="s1", artifact_type="nope")
+
+
+def test_get_artifact_resolves_config_snapshot(store):
+    saved = save_config_snapshot_core(store, space_id="s1", serialized_space='{"v":1}')
+    found = get_artifact_core(store, id=saved["config_version_id"])
+    assert found["ok"] is True
+    assert found["type"] == "config_snapshot"
+    assert found["table"] == schema.CONFIG_SNAPSHOTS
+    assert found["record"]["config_json"] == '{"v":1}'
+
+
+def test_get_artifact_resolves_report_across_tables(store):
+    saved = save_report_core(
+        store,
+        space_id="s1",
+        artifact_type="diagnose_report",
+        title="t",
+        content_md="body",
+    )
+    found = get_artifact_core(store, id=saved["artifact_id"])
+    assert found["ok"] is True
+    assert found["type"] == "diagnose_report"
+    assert found["table"] == schema.DIAGNOSE_REPORTS
+    assert found["record"]["content_md"] == "body"
+
+
+def test_get_artifact_not_found(store):
+    result = get_artifact_core(store, id="does-not-exist")
+    assert result["ok"] is False
+    assert result["error_type"] == "not_found"
+
+
+def test_get_artifact_requires_id(store):
+    with pytest.raises(ToolValidationError):
+        get_artifact_core(store, id="")

--- a/genie-code/mcp-genie-space-history/app/tests/test_list_get.py
+++ b/genie-code/mcp-genie-space-history/app/tests/test_list_get.py
@@ -46,6 +46,20 @@ def test_list_history_filter_restricts_to_one_table(store, backend):
     assert schema.QUERY_REPORTS not in list_sql
 
 
+def test_list_history_orders_newest_first_by_created_at(store, backend):
+    # Two config snapshots that differ only by created_at — newest must come first,
+    # with the artifact id as a stable secondary tiebreaker (deterministic pagination).
+    newest = ["id-new", "config_snapshot", None, "2026-01-02T00:00:00Z", "alice", "v2", None]
+    oldest = ["id-old", "config_snapshot", None, "2026-01-01T00:00:00Z", "alice", "v1", None]
+    backend.list_result = QueryResult(_LIST_COLUMNS, [newest, oldest])
+
+    result = list_history_core(store, space_id="s1")
+    assert [row["id"] for row in result["items"]] == ["id-new", "id-old"]
+
+    list_sql, _params = backend.calls[-1]
+    assert "ORDER BY created_at DESC, id ASC" in list_sql
+
+
 def test_list_history_since_binds_param(store, backend):
     backend.list_result = QueryResult(_LIST_COLUMNS, [])
     list_history_core(store, space_id="s1", since="2026-01-01T00:00:00Z")

--- a/genie-code/mcp-genie-space-history/app/tests/test_provisioning.py
+++ b/genie-code/mcp-genie-space-history/app/tests/test_provisioning.py
@@ -86,6 +86,22 @@ def test_bootstrap_required_tblproperties_present(monkeypatch, settings):
         assert "'delta.feature.allowColumnDefaults' = 'supported'" in ddl
 
 
+def test_fresh_config_snapshots_table_has_no_version_column(monkeypatch, settings):
+    recorded = _install_fake_exec(monkeypatch)
+    provisioning.bootstrap(_fake_workspace_client(), settings)
+
+    create = next(
+        s for s in recorded if "CREATE TABLE IF NOT EXISTS" in s and schema.CONFIG_SNAPSHOTS in s
+    )
+    # The monotonic version counter is gone — a fresh table has no bare ``version`` column
+    # (config_version_id / parent_version_id remain; they hold ids, not a counter).
+    column_lines = [ln.strip() for ln in create.splitlines()]
+    assert not any(ln.startswith("version ") for ln in column_lines)
+    # The identity/ordering columns remain.
+    assert "config_version_id" in create
+    assert "created_at" in create
+
+
 def test_ownership_failure_is_warning_not_crash(monkeypatch, settings):
     _install_fake_exec(monkeypatch, fail_substrings=("OWNER TO",))
     report = provisioning.bootstrap(_fake_workspace_client(), settings)

--- a/genie-code/mcp-genie-space-history/app/tests/test_provisioning.py
+++ b/genie-code/mcp-genie-space-history/app/tests/test_provisioning.py
@@ -50,13 +50,29 @@ def test_bootstrap_happy_path(monkeypatch, settings):
         ), table_name
     assert sorted(report["tables_created"]) == sorted(schema.ALL_TABLE_NAMES)
 
-    # Row-filter function + row filters on each table.
+    # Row-filter function + row filters on each table; all 7 reported as filtered.
     assert any("CREATE FUNCTION IF NOT EXISTS" in stmt for stmt in recorded)
     for table_name in schema.ALL_TABLE_NAMES:
         assert any("SET ROW FILTER" in stmt and table_name in stmt for stmt in recorded)
+    assert sorted(report["row_filtered"]) == sorted(schema.ALL_TABLE_NAMES)
+    assert report["grants_withheld"] == []
+    assert report["errors"] == []
 
-    # Grants to the grantee + ownership handoff to the durable group.
-    assert any("GRANT USE SCHEMA, SELECT, MODIFY ON SCHEMA" in stmt for stmt in recorded)
+    # Grantee gets PER-TABLE SELECT/MODIFY (never schema-wide) + USE SCHEMA traversal.
+    assert not any("SELECT, MODIFY ON SCHEMA" in stmt for stmt in recorded)
+    assert any(
+        "GRANT USE SCHEMA ON SCHEMA" in stmt and settings.history_grantee in stmt
+        for stmt in recorded
+    )
+    for table_name in schema.ALL_TABLE_NAMES:
+        assert any(
+            "GRANT SELECT, MODIFY ON TABLE" in stmt
+            and table_name in stmt
+            and settings.history_grantee in stmt
+            for stmt in recorded
+        ), table_name
+
+    # Ownership handoff to the durable group.
     assert any("OWNER TO" in stmt and settings.history_owner_group in stmt for stmt in recorded)
 
 
@@ -74,11 +90,57 @@ def test_ownership_failure_is_warning_not_crash(monkeypatch, settings):
     _install_fake_exec(monkeypatch, fail_substrings=("OWNER TO",))
     report = provisioning.bootstrap(_fake_workspace_client(), settings)
 
-    # The data path is still usable (schema + tables created) ...
+    # Row isolation is intact (function + all filters applied) so ok stays True ...
     assert report["ok"] is True
-    # ... and every OWNER TO failure was captured as a structured warning.
+    # ... OWNER TO is the ONLY step allowed to warn-and-continue ...
     assert report["warnings"]
     assert all("owner_to" in w for w in report["warnings"])
+    # ... and it is NOT treated as a hard error.
+    assert report["errors"] == []
+
+
+def test_row_filter_failure_withholds_grant_and_fails(monkeypatch, settings):
+    # Fail the row filter for exactly one table.
+    target = schema.CONFIG_SNAPSHOTS
+    recorded = _install_fake_exec(monkeypatch, fail_substrings=(f"`{target}` SET ROW FILTER",))
+    report = provisioning.bootstrap(_fake_workspace_client(), settings)
+
+    # Bootstrap is NOT ok because not every table is row-filtered.
+    assert report["ok"] is False
+    assert target not in report["row_filtered"]
+    # The grantee grant on the unfiltered table is WITHHELD (security gate).
+    assert target in report["grants_withheld"]
+    assert not any(
+        "GRANT SELECT, MODIFY ON TABLE" in stmt
+        and target in stmt
+        and settings.history_grantee in stmt
+        for stmt in recorded
+    )
+    # Other (filtered) tables still get their grantee grant.
+    other = schema.QUERY_REPORTS
+    assert other in report["row_filtered"]
+    assert any(
+        "GRANT SELECT, MODIFY ON TABLE" in stmt
+        and other in stmt
+        and settings.history_grantee in stmt
+        for stmt in recorded
+    )
+
+
+def test_function_failure_blocks_all_filters_and_grantee_access(monkeypatch, settings):
+    recorded = _install_fake_exec(monkeypatch, fail_substrings=("CREATE FUNCTION",))
+    report = provisioning.bootstrap(_fake_workspace_client(), settings)
+
+    assert report["ok"] is False
+    assert report["row_filtered"] == []
+    # Without the row-filter function, NO row filter is applied ...
+    assert not any("SET ROW FILTER" in stmt for stmt in recorded)
+    # ... and EVERY table's grantee access is withheld.
+    assert sorted(report["grants_withheld"]) == sorted(schema.ALL_TABLE_NAMES)
+    assert not any(
+        "GRANT SELECT, MODIFY ON TABLE" in stmt and settings.history_grantee in stmt
+        for stmt in recorded
+    )
 
 
 def test_catalog_inaccessible_returns_early_without_creating_anything(monkeypatch, settings):

--- a/genie-code/mcp-genie-space-history/app/tests/test_provisioning.py
+++ b/genie-code/mcp-genie-space-history/app/tests/test_provisioning.py
@@ -1,0 +1,106 @@
+"""Bootstrap: idempotent, never creates the catalog, ownership failure → WARNING not crash."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from server import provisioning, schema
+from server.sql import SqlError
+
+
+class _FakeResp:
+    def __init__(self, data_array=None):
+        self.result = SimpleNamespace(data_array=data_array) if data_array is not None else None
+
+
+def _fake_workspace_client() -> Any:
+    # A duck-typed stand-in for WorkspaceClient (only current_user.me() is used).
+    me = SimpleNamespace(user_name="sp-app-12345")
+    return SimpleNamespace(current_user=SimpleNamespace(me=lambda: me))
+
+
+def _install_fake_exec(monkeypatch, *, fail_substrings=()):
+    recorded: list[str] = []
+
+    def fake_exec(w, warehouse_id, statement, **kwargs):
+        recorded.append(statement)
+        for sub in fail_substrings:
+            if sub in statement:
+                raise SqlError(f"forced failure: {sub}", state="ERROR", statement=statement)
+        # SHOW TABLES ... LIKE returns no rows -> table treated as newly created.
+        return _FakeResp(data_array=None)
+
+    monkeypatch.setattr(provisioning, "exec_sql", fake_exec)
+    return recorded
+
+
+def test_bootstrap_happy_path(monkeypatch, settings):
+    recorded = _install_fake_exec(monkeypatch)
+    report = provisioning.bootstrap(_fake_workspace_client(), settings)
+
+    assert report["ok"] is True
+    assert report["catalog_created"] is False
+    assert not any(stmt.upper().startswith("CREATE CATALOG") for stmt in recorded)
+
+    # All seven tables created.
+    for table_name in schema.ALL_TABLE_NAMES:
+        assert any(
+            "CREATE TABLE IF NOT EXISTS" in stmt and table_name in stmt for stmt in recorded
+        ), table_name
+    assert sorted(report["tables_created"]) == sorted(schema.ALL_TABLE_NAMES)
+
+    # Row-filter function + row filters on each table.
+    assert any("CREATE FUNCTION IF NOT EXISTS" in stmt for stmt in recorded)
+    for table_name in schema.ALL_TABLE_NAMES:
+        assert any("SET ROW FILTER" in stmt and table_name in stmt for stmt in recorded)
+
+    # Grants to the grantee + ownership handoff to the durable group.
+    assert any("GRANT USE SCHEMA, SELECT, MODIFY ON SCHEMA" in stmt for stmt in recorded)
+    assert any("OWNER TO" in stmt and settings.history_owner_group in stmt for stmt in recorded)
+
+
+def test_bootstrap_required_tblproperties_present(monkeypatch, settings):
+    recorded = _install_fake_exec(monkeypatch)
+    provisioning.bootstrap(_fake_workspace_client(), settings)
+    creates = [s for s in recorded if "CREATE TABLE IF NOT EXISTS" in s]
+    assert len(creates) == 7
+    for ddl in creates:
+        assert "delta.enableRowTracking = true" in ddl
+        assert "'delta.feature.allowColumnDefaults' = 'supported'" in ddl
+
+
+def test_ownership_failure_is_warning_not_crash(monkeypatch, settings):
+    _install_fake_exec(monkeypatch, fail_substrings=("OWNER TO",))
+    report = provisioning.bootstrap(_fake_workspace_client(), settings)
+
+    # The data path is still usable (schema + tables created) ...
+    assert report["ok"] is True
+    # ... and every OWNER TO failure was captured as a structured warning.
+    assert report["warnings"]
+    assert all("owner_to" in w for w in report["warnings"])
+
+
+def test_catalog_inaccessible_returns_early_without_creating_anything(monkeypatch, settings):
+    recorded = _install_fake_exec(monkeypatch, fail_substrings=("SHOW SCHEMAS",))
+    report = provisioning.bootstrap(_fake_workspace_client(), settings)
+
+    assert report["ok"] is False
+    assert "note" in report
+    # No schema/table creation attempted once the catalog is unreachable.
+    assert not any("CREATE TABLE" in stmt for stmt in recorded)
+    assert not any("CREATE SCHEMA" in stmt for stmt in recorded)
+
+
+def test_bootstrap_is_rerunnable(monkeypatch, settings):
+    _install_fake_exec(monkeypatch)
+    first = provisioning.bootstrap(_fake_workspace_client(), settings)
+    second = provisioning.bootstrap(_fake_workspace_client(), settings)
+    assert first["ok"] is True
+    assert second["ok"] is True
+
+
+def test_never_creates_catalog_even_on_failures(monkeypatch, settings):
+    recorded = _install_fake_exec(monkeypatch, fail_substrings=("OWNER TO", "GRANT"))
+    provisioning.bootstrap(_fake_workspace_client(), settings)
+    assert not any("CREATE CATALOG" in stmt.upper() for stmt in recorded)

--- a/genie-code/mcp-genie-space-history/app/tests/test_reports.py
+++ b/genie-code/mcp-genie-space-history/app/tests/test_reports.py
@@ -2,13 +2,17 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
+from fastmcp import FastMCP
 
 from server import schema
+from server import tools as tools_module
 from server.config import Settings
 from server.errors import ToolValidationError
 from server.store import UCTableStore
-from server.tools import save_report_core
+from server.tools import register_tools, save_report_core
 
 from .conftest import InMemoryBackend, param_value
 
@@ -120,9 +124,54 @@ def test_report_idempotency_key_dedupes(store, backend):
     assert len(backend.inserts_into(schema.DIAGNOSE_REPORTS)) == 1
 
 
-def test_created_by_stamped_on_reports(store, backend):
+def test_created_by_is_server_side_current_user(store, backend):
     save_report_core(
         store, space_id="s1", artifact_type="diagnose_report", title="t", content_md="c"
     )
+    sql, params = backend.inserts_into(schema.DIAGNOSE_REPORTS)[-1]
+    # created_by uses current_user() so it matches the only_mine SESSION_USER() filter.
+    assert "current_user()" in sql
+    assert param_value(params, "created_by") is None
+
+
+# --- N1: accept the spec's `redact` spelling as an alias for `redacted` -----
+def _registered_tools(settings: Settings):
+    mcp = FastMCP(name="test")
+    register_tools(mcp, settings)
+    return asyncio.run(mcp.get_tools())  # type: ignore[attr-defined]
+
+
+def test_save_report_schema_accepts_both_redact_and_redacted(settings):
+    tool = _registered_tools(settings)["save_report"]
+    props = tool.parameters["properties"]
+    assert "redact" in props
+    assert "redacted" in props
+
+
+def test_redact_alias_overrides_redacted(settings, monkeypatch):
+    backend = InMemoryBackend()
+    store = UCTableStore(backend, settings, user_name="alice@example.com")
+    monkeypatch.setattr(tools_module, "_build_user_store", lambda _s: store)
+
+    tool = _registered_tools(settings)["save_report"]
+    result = tool.fn(
+        space_id="s1",
+        artifact_type="diagnose_report",
+        title="t",
+        content_md="c",
+        redact=False,
+    )
+    assert result["ok"] is True
     _sql, params = backend.inserts_into(schema.DIAGNOSE_REPORTS)[-1]
-    assert param_value(params, "created_by") == "alice@example.com"
+    assert param_value(params, "redacted") == "false"
+
+
+def test_redact_defaults_true_via_tool(settings, monkeypatch):
+    backend = InMemoryBackend()
+    store = UCTableStore(backend, settings, user_name="alice@example.com")
+    monkeypatch.setattr(tools_module, "_build_user_store", lambda _s: store)
+
+    tool = _registered_tools(settings)["save_report"]
+    tool.fn(space_id="s1", artifact_type="query_report", title="t", content_md="c")
+    _sql, params = backend.inserts_into(schema.QUERY_REPORTS)[-1]
+    assert param_value(params, "redacted") == "true"

--- a/genie-code/mcp-genie-space-history/app/tests/test_reports.py
+++ b/genie-code/mcp-genie-space-history/app/tests/test_reports.py
@@ -1,0 +1,128 @@
+"""save_report: artifact_type routing, unknown-type rejection, redaction, dedupe."""
+
+from __future__ import annotations
+
+import pytest
+
+from server import schema
+from server.config import Settings
+from server.errors import ToolValidationError
+from server.store import UCTableStore
+from server.tools import save_report_core
+
+from .conftest import InMemoryBackend, param_value
+
+ROUTING = [
+    ("diagnose_report", schema.DIAGNOSE_REPORTS),
+    ("query_report", schema.QUERY_REPORTS),
+    ("design_proposal", schema.DESIGN_PROPOSALS),
+    ("metric_view_ddl", schema.METRIC_VIEW_ARTIFACTS),
+]
+
+
+def _fresh_store(settings: Settings):
+    backend = InMemoryBackend()
+    return backend, UCTableStore(backend, settings, user_name="alice@example.com")
+
+
+@pytest.mark.parametrize("artifact_type,table_name", ROUTING)
+def test_artifact_type_routes_to_correct_table(settings, artifact_type, table_name):
+    backend, store = _fresh_store(settings)
+    result = save_report_core(
+        store,
+        space_id="s1",
+        artifact_type=artifact_type,
+        title="A report",
+        content_md="# heading\nbody",
+    )
+    assert result["ok"] is True
+    # Exactly one insert, and it targets the routed table only.
+    assert len(backend.inserts_into(table_name)) == 1
+    assert len(backend.all_inserts()) == 1
+
+
+def test_unknown_artifact_type_is_rejected(store):
+    with pytest.raises(ToolValidationError):
+        save_report_core(
+            store,
+            space_id="s1",
+            artifact_type="totally_bogus",
+            title="t",
+            content_md="c",
+        )
+
+
+def test_redacted_defaults_to_true(store, backend):
+    save_report_core(
+        store, space_id="s1", artifact_type="diagnose_report", title="t", content_md="c"
+    )
+    _sql, params = backend.inserts_into(schema.DIAGNOSE_REPORTS)[-1]
+    assert param_value(params, "redacted") == "true"
+
+
+def test_redacted_can_be_disabled(store, backend):
+    save_report_core(
+        store,
+        space_id="s1",
+        artifact_type="diagnose_report",
+        title="t",
+        content_md="c",
+        redacted=False,
+    )
+    _sql, params = backend.inserts_into(schema.DIAGNOSE_REPORTS)[-1]
+    assert param_value(params, "redacted") == "false"
+
+
+def test_summary_derived_from_first_line_when_absent(store, backend):
+    save_report_core(
+        store,
+        space_id="s1",
+        artifact_type="query_report",
+        title="t",
+        content_md="First line summary\nmore detail here",
+    )
+    _sql, params = backend.inserts_into(schema.QUERY_REPORTS)[-1]
+    assert param_value(params, "summary") == "First line summary"
+
+
+def test_explicit_summary_is_kept(store, backend):
+    save_report_core(
+        store,
+        space_id="s1",
+        artifact_type="query_report",
+        title="t",
+        content_md="First line\nbody",
+        summary="explicit summary",
+    )
+    _sql, params = backend.inserts_into(schema.QUERY_REPORTS)[-1]
+    assert param_value(params, "summary") == "explicit summary"
+
+
+def test_report_idempotency_key_dedupes(store, backend):
+    r1 = save_report_core(
+        store,
+        space_id="s1",
+        artifact_type="diagnose_report",
+        title="t",
+        content_md="c",
+        idempotency_key="run-42",
+    )
+    r2 = save_report_core(
+        store,
+        space_id="s1",
+        artifact_type="diagnose_report",
+        title="t (retry)",
+        content_md="c",
+        idempotency_key="run-42",
+    )
+    assert r2["deduplicated"] is True
+    assert r2["artifact_id"] == r1["artifact_id"]
+    assert len(backend.inserts_into(schema.DIAGNOSE_REPORTS)) == 1
+
+
+def test_created_by_stamped_on_reports(store, backend):
+    save_report_core(
+        store, space_id="s1", artifact_type="diagnose_report", title="t", content_md="c"
+    )
+    _sql, params = backend.inserts_into(schema.DIAGNOSE_REPORTS)[-1]
+    assert param_value(params, "created_by") == "alice@example.com"

--- a/genie-code/mcp-genie-space-history/app/tests/test_reports.py
+++ b/genie-code/mcp-genie-space-history/app/tests/test_reports.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from typing import Any
 
 import pytest
 from fastmcp import FastMCP
@@ -135,14 +136,17 @@ def test_created_by_is_server_side_current_user(store, backend):
 
 
 # --- N1: accept the spec's `redact` spelling as an alias for `redacted` -----
-def _registered_tools(settings: Settings):
+def _registered_tool(settings: Settings, name: str) -> Any:
+    # get_tool(name) is the public single-tool accessor present in the pinned
+    # FastMCP (3.x). It returns a FunctionTool with .parameters (JSON schema) + .fn;
+    # typed as Any here since we introspect those attributes dynamically.
     mcp = FastMCP(name="test")
     register_tools(mcp, settings)
-    return asyncio.run(mcp.get_tools())  # type: ignore[attr-defined]
+    return asyncio.run(mcp.get_tool(name))
 
 
 def test_save_report_schema_accepts_both_redact_and_redacted(settings):
-    tool = _registered_tools(settings)["save_report"]
+    tool = _registered_tool(settings, "save_report")
     props = tool.parameters["properties"]
     assert "redact" in props
     assert "redacted" in props
@@ -153,7 +157,7 @@ def test_redact_alias_overrides_redacted(settings, monkeypatch):
     store = UCTableStore(backend, settings, user_name="alice@example.com")
     monkeypatch.setattr(tools_module, "_build_user_store", lambda _s: store)
 
-    tool = _registered_tools(settings)["save_report"]
+    tool = _registered_tool(settings, "save_report")
     result = tool.fn(
         space_id="s1",
         artifact_type="diagnose_report",
@@ -171,7 +175,7 @@ def test_redact_defaults_true_via_tool(settings, monkeypatch):
     store = UCTableStore(backend, settings, user_name="alice@example.com")
     monkeypatch.setattr(tools_module, "_build_user_store", lambda _s: store)
 
-    tool = _registered_tools(settings)["save_report"]
+    tool = _registered_tool(settings, "save_report")
     tool.fn(space_id="s1", artifact_type="query_report", title="t", content_md="c")
     _sql, params = backend.inserts_into(schema.QUERY_REPORTS)[-1]
     assert param_value(params, "redacted") == "true"

--- a/genie-code/mcp-genie-space-history/app/tests/test_scope_error.py
+++ b/genie-code/mcp-genie-space-history/app/tests/test_scope_error.py
@@ -1,0 +1,90 @@
+"""The scope_error path (spec §5): missing OBO token / disabled OBO never falls back to SP."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from server import auth, tools
+from server.errors import OBOScopeError, looks_like_scope_error, scope_error_payload
+from server.sql import SqlError
+
+
+def _never_runs(_store):
+    raise AssertionError("core must not run when OBO auth fails")
+
+
+@pytest.fixture
+def no_obo_token():
+    """Ensure the per-request OBO token ContextVar is unset for the test."""
+    reset = auth.obo_token_var.set(None)
+    try:
+        yield
+    finally:
+        auth.obo_token_var.reset(reset)
+
+
+def test_missing_obo_token_in_app_returns_scope_error(monkeypatch, settings, no_obo_token):
+    # Simulate running inside a deployed App with NO forwarded token.
+    monkeypatch.setenv("DATABRICKS_APP_NAME", "mcp-genie-space-history")
+
+    result = tools._run_tool(settings, "save_config_snapshot", _never_runs)
+
+    assert result["ok"] is False
+    assert result["error_type"] == "scope_error"
+    assert result["required_scope"] == "sql"
+    assert "user_api_scopes" in result["remediation"]
+
+
+def test_disabled_obo_returns_scope_error(monkeypatch, settings):
+    # OBO disabled raises before the token is ever consulted.
+    monkeypatch.setenv("DATABRICKS_APP_NAME", "mcp-genie-space-history")
+    disabled = dataclasses.replace(settings, obo_enabled=False)
+
+    result = tools._run_tool(disabled, "list_history", _never_runs)
+
+    assert result["error_type"] == "scope_error"
+
+
+def test_get_user_workspace_client_raises_when_token_missing(monkeypatch, no_obo_token):
+    monkeypatch.setenv("DATABRICKS_APP_NAME", "mcp-genie-space-history")
+    with pytest.raises(OBOScopeError):
+        auth.get_user_workspace_client(obo_enabled=True)
+
+
+def test_sql_layer_scope_failure_is_classified(monkeypatch, settings, store):
+    # A SqlError whose message looks like an OAuth-scope failure maps to scope_error.
+    def boom(_store):
+        raise SqlError("403 Unauthorized: insufficient_scope", state="ERROR")
+
+    monkeypatch.setattr(tools, "_build_user_store", lambda _s: store)
+    result = tools._run_tool(settings, "save_report", boom)
+    assert result["error_type"] == "scope_error"
+
+
+def test_ordinary_sql_error_is_not_scope_error(monkeypatch, settings, store):
+    def boom(_store):
+        raise SqlError("SQL FAILED: table not found", state="ERROR")
+
+    monkeypatch.setattr(tools, "_build_user_store", lambda _s: store)
+    result = tools._run_tool(settings, "save_report", boom)
+    assert result["error_type"] == "sql_error"
+
+
+def test_scope_error_classifier_is_conservative():
+    # A plain UC grant denial must NOT be mislabeled an OAuth-scope error.
+    assert looks_like_scope_error(SqlError("PERMISSION_DENIED: no SELECT on table")) is False
+    assert looks_like_scope_error(SqlError("invalid_token")) is True
+
+
+def test_scope_error_payload_shape():
+    payload = scope_error_payload("nope", required_scope="sql")
+    assert payload == {
+        "ok": False,
+        "error_type": "scope_error",
+        "required_scope": "sql",
+        "message": "nope",
+        "remediation": payload["remediation"],
+    }
+    assert "sql" in payload["remediation"]

--- a/genie-code/mcp-genie-space-history/app/tests/test_scope_error.py
+++ b/genie-code/mcp-genie-space-history/app/tests/test_scope_error.py
@@ -78,6 +78,43 @@ def test_scope_error_classifier_is_conservative():
     assert looks_like_scope_error(SqlError("invalid_token")) is True
 
 
+# --- N2: token/identity-auth failures during current_user.me() -> scope_error ---
+def test_classifier_detects_unauthenticated_by_class_name():
+    # The SDK's Unauthenticated (401) is detected by class name, even with a generic
+    # message; PermissionDenied (403, a UC grant denial) is NOT a scope error.
+    class Unauthenticated(Exception):
+        pass
+
+    class PermissionDenied(Exception):
+        pass
+
+    assert looks_like_scope_error(Unauthenticated("token rejected")) is True
+    assert looks_like_scope_error(PermissionDenied("forbidden")) is False
+
+
+def test_identity_resolution_auth_failure_maps_to_scope_error(monkeypatch, settings):
+    # An auth failure raised while building the OBO store (e.g. me()) -> scope_error,
+    # not internal_error.
+    class Unauthenticated(Exception):
+        pass
+
+    def boom(_settings):
+        raise Unauthenticated("401: token lacks required scope")
+
+    monkeypatch.setattr(tools, "_build_user_store", boom)
+    result = tools._run_tool(settings, "save_config_snapshot", _never_runs)
+    assert result["error_type"] == "scope_error"
+
+
+def test_generic_internal_error_is_not_scope_error(monkeypatch, settings):
+    def boom(_settings):
+        raise RuntimeError("something unrelated blew up")
+
+    monkeypatch.setattr(tools, "_build_user_store", boom)
+    result = tools._run_tool(settings, "save_config_snapshot", _never_runs)
+    assert result["error_type"] == "internal_error"
+
+
 def test_scope_error_payload_shape():
     payload = scope_error_payload("nope", required_scope="sql")
     assert payload == {


### PR DESCRIPTION
## Summary

Productionizes the immutable P0 spike (`genie-code/mcp-genie-space-history/spike/`) into a real `app/` package: a **FastAPI + FastMCP** server mounted at **`/mcp`** (stateless streamable HTTP), **OBO-only** for all user reads/writes, with the **full §7.1 schema** (7 UC Delta tables) and the **four P1 tools**. Built strictly per `genie-code/genie-space-history-mcp-design.md` (§5/§6/§7.1/§10/§11/§13).

Nothing in `spike/` or any `SKILL.md` is touched.

## Module layout (`app/server/`)

| Module | Role |
| --- | --- |
| `config.py` | env-driven `Settings` (catalog/owner-group/grantee/warehouse, CORS, VARIANT opt-in, OBO flag); schema name fixed `genie_space_history` |
| `auth.py` | per-request OBO `WorkspaceClient` from `X-Forwarded-Access-Token` (never cached); app-SP client for bootstrap only; `OBOScopeError` — never falls back to SP for a user write |
| `sql.py` | `exec_sql` (server-side param binding + polling), identifier validation/quoting, SDK-free `Param`/`QueryResult` adapter |
| `schema.py` | DDL for all 7 tables (`delta.enableRowTracking` + `allowColumnDefaults`), `only_mine` row filter, JSON cols STRING-default / VARIANT-opt-in, list/get registry |
| `provisioning.py` | idempotent app-SP bootstrap: create schema + 7 tables + function, apply row filter, grant grantee + retain SP `SELECT/MODIFY`, reassign `OWNER TO` group (warn+continue); never creates catalog, never crashes startup |
| `store.py` | `UCTableStore` — version monotonicity, sha256 `config_hash`, lineage, idempotency dedupe, `list_history` UNION, `get_artifact` resolution |
| `tools.py` | the four tools + OBO/`scope_error`/`validation_error` wrapping + per-call logging |
| `app.py` / `main.py` | `/mcp` mount, CORS allowlist, OBO middleware, lifespan bootstrap, uvicorn entrypoint (`DATABRICKS_APP_PORT`) |

## The four P1 tools (§6, all OBO)

- **`save_config_snapshot`** — caller supplies `serialized_space`; server computes monotonic per-`space_id` `version`, sha256 `config_hash`, stores caller `etag` verbatim, sets lineage via `parent_config_version_id`. → `{config_version_id, version, config_hash, etag}`.
- **`save_report`** — routes `artifact_type` to `diagnose_reports`/`query_reports`/`design_proposals`/`metric_view_artifacts`; rejects unknown types; `redacted` defaults true. → `{artifact_id}`.
- **`list_history`** — UNION across all artifact tables; optional `artifact_type`/`since`. → `{items:[{id,type,version,created_at,created_by,summary,decision}]}`.
- **`get_artifact`** — resolves a `config_version_id`/`artifact_id`/`run_id` across all 7 tables (incl. the writer-less `optimization_runs`/`eval_results`) → full record.

## Packaging
`app.yaml` (declares `user_api_scopes: sql` + env), `requirements.txt` (`databricks-sdk>=0.118.0`, fastapi, uvicorn, fastmcp, mcp[cli], pydantic), `pyproject.toml` (ruff + pyright + pytest), `README.md`.

## Tests & gates (no live workspace)
45 pytest cases mocking the SQL/WorkspaceClient layer: version monotonicity, config_hash, lineage, artifact_type routing + unknown-type rejection, id resolution across tables, redaction default, the `scope_error` path, idempotency dedupe, and bootstrap idempotency / ownership-warning / catalog-never-created.

- `python -m pytest` → **45 passed**
- `uvx ruff check .` → **All checks passed**; `uvx ruff format --check .` → **18 files already formatted**
- `uvx --with <deps> pyright` → **0 errors, 0 warnings**
- ASGI smoke (TestClient): lifespan startup/shutdown OK, `/healthz` 200, `/mcp` mounted.

## Out of scope (not built)
`record_optimization_run` (P2), `diff_configs` (P3), DABs/CI packaging (P4), `SKILL.md` edits (P5).

## Deviations / notes
- **`version_label`** has no column in §7.1 `config_snapshots`; accepted for API compat and folded into `change_summary` only when `change_summary` is absent.
- Added optional, schema-grounded inputs beyond the §6 list but present as real columns: `skill_name` (both writers), `config_version_id`/`summary`/`redacted` (reports). Additive only.
- `version` monotonicity is computed from OBO-visible rows, so under the `only_mine` row filter it is per-(space, user) — the intended private-history semantics (§5; private-vs-shared is still an open spec question).
- `scope_error` classification of SQL failures is intentionally conservative (token/scope markers only); a plain UC grant denial is **not** mislabeled.

The PR opener does not merge.