### PR TITLE
feat(mcp-genie-space-history): add record_optimization_run tool (P2)

### DIFF
--- a/genie-code/mcp-genie-space-history/app/server/store.py
+++ b/genie-code/mcp-genie-space-history/app/server/store.py
@@ -27,7 +27,7 @@ from __future__ import annotations
 import hashlib
 import json
 import uuid
-from typing import Any, Optional, Sequence
+from typing import Any, Mapping, Optional, Sequence
 
 from . import schema
 from .config import Settings
@@ -267,6 +267,101 @@ class UCTableStore:
         self._run(sql, params)
         return {"artifact_id": artifact_id, "deduplicated": False}
 
+    # --- record_optimization_run ------------------------------------------
+    def record_optimization_run(
+        self,
+        *,
+        space_id: str,
+        run_id: str,
+        eval_results: Sequence[Mapping[str, Any]] = (),
+        baseline_score: Optional[float] = None,
+        candidate_score: Optional[float] = None,
+        score_delta: Optional[float] = None,
+        fixed_count: Optional[int] = None,
+        regressed_count: Optional[int] = None,
+        unchanged_count: Optional[int] = None,
+        excluded_count: Optional[int] = None,
+        decision: Optional[str] = None,
+        parent_config_version_id: Optional[str] = None,
+        result_config_version_id: Optional[str] = None,
+        change_summary: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
+    ) -> dict:
+        """Persist one ``optimization_runs`` row + N ``eval_results`` rows (FK ``run_id``).
+
+        Returns ``{run_id, eval_count, deduplicated}``. The stored ``run_id`` is derived
+        deterministically from the idempotency key (default: the caller's ``run_id``), so a
+        retried record resolves to the existing run instead of inserting a duplicate — the
+        same read-before-write pattern as ``save_config_snapshot``/``save_report`` (spec §6).
+        On a dedupe hit the eval rows are **not** re-inserted.
+
+        Each ``eval_results`` entry gets a stable ``eval_run_id`` derived from the run id +
+        its position, and inherits the run's ``space_id``; ``created_at``/``created_by`` are
+        stamped server-side on every row (spec §6/§7.1).
+        """
+        idem = idempotency_key or run_id
+        run_row_id = _derive_id(f"run:{space_id}", idem)
+        spec = next(s for s in schema.TABLE_SPECS if s.name == schema.OPTIMIZATION_RUNS)
+
+        # Idempotency read-before-write: a repeated key resolves to the existing run row
+        # rather than inserting a duplicate run (and its eval rows again) (spec §6).
+        existing = self._find_by_id(spec, run_row_id)
+        if existing is not None:
+            return {
+                "run_id": existing.get("run_id"),
+                "eval_count": len(eval_results),
+                "deduplicated": True,
+            }
+
+        b = _InsertBuilder()
+        b.set("run_id", run_row_id)
+        b.set("space_id", space_id)
+        b.set_raw("created_at", "current_timestamp()")
+        b.set_raw("created_by", "current_user()")
+        b.set("baseline_score", baseline_score)
+        b.set("candidate_score", candidate_score)
+        b.set("score_delta", score_delta)
+        b.set("fixed_count", fixed_count)
+        b.set("regressed_count", regressed_count)
+        b.set("unchanged_count", unchanged_count)
+        b.set("excluded_count", excluded_count)
+        b.set("decision", decision)
+        b.set("parent_config_version_id", parent_config_version_id)
+        b.set("result_config_version_id", result_config_version_id)
+        b.set("change_summary", change_summary)
+        sql, params = b.build(self._fq_table(schema.OPTIMIZATION_RUNS))
+        self._run(sql, params)
+
+        for index, entry in enumerate(eval_results):
+            self._insert_eval_result(run_row_id, space_id, index, entry)
+
+        return {"run_id": run_row_id, "eval_count": len(eval_results), "deduplicated": False}
+
+    def _insert_eval_result(
+        self, run_id: str, space_id: str, index: int, entry: Mapping[str, Any]
+    ) -> None:
+        """Insert one ``eval_results`` row (FK ``run_id``) for an already-validated entry."""
+        question_id = entry.get("question_id")
+        # Stable per-row PK: same (run, position) always yields the same id, so a row is
+        # never silently duplicated even if the loop re-runs (spec §7.1).
+        eval_run_id = _derive_id(f"eval:{run_id}", f"{index}:{question_id or ''}")
+        b = _InsertBuilder()
+        b.set("eval_run_id", eval_run_id)
+        b.set("run_id", run_id)
+        b.set("space_id", space_id)
+        b.set_raw("created_at", "current_timestamp()")
+        b.set_raw("created_by", "current_user()")
+        b.set("question_id", question_id)
+        b.set("assessment", entry.get("assessment"))
+        b.set("primary_failure", entry.get("primary_failure"))
+        b.set("baseline_sql_hash", entry.get("baseline_sql_hash"))
+        b.set("candidate_sql_hash", entry.get("candidate_sql_hash"))
+        b.set("baseline_result_digest", entry.get("baseline_result_digest"))
+        b.set("candidate_result_digest", entry.get("candidate_result_digest"))
+        b.set("latency_ms", entry.get("latency_ms"))
+        sql, params = b.build(self._fq_table(schema.EVAL_RESULTS))
+        self._run(sql, params)
+
     # --- list_history ------------------------------------------------------
     def list_history(
         self,
@@ -320,7 +415,9 @@ class UCTableStore:
         """Resolve an id across all tables; returns the full record or ``None``.
 
         Searches each table's logical-PK column in order (config first). Optimization
-        runs / eval results have no P1 write tool but are resolved here (spec §6).
+        runs are written by ``record_optimization_run`` (P2) and resolved here by ``run_id``;
+        eval-result rows have no dedicated get tool but are resolved here by ``eval_run_id``
+        (spec §6).
         """
         for spec in schema.TABLE_SPECS:
             record = self._find_by_id(spec, id_value)

--- a/genie-code/mcp-genie-space-history/app/server/tools.py
+++ b/genie-code/mcp-genie-space-history/app/server/tools.py
@@ -1,4 +1,5 @@
-"""The four P1 MCP tools (spec §6), plus their input validation.
+"""The P1 write/read MCP tools plus the P2 ``record_optimization_run`` tool (spec §6),
+with their input validation.
 
 Split into two layers so the logic is unit-testable with no live workspace:
 
@@ -38,6 +39,57 @@ def _require(value: Optional[str], name: str) -> str:
     if value is None or (isinstance(value, str) and not value.strip()):
         raise ToolValidationError(f"`{name}` is required and must be non-empty.")
     return value
+
+
+# Allowed keys on an `eval_results[]` entry (spec §7.1 eval_results columns the caller
+# supplies — server-stamped eval_run_id/run_id/space_id/created_* are NOT caller fields).
+_EVAL_STR_FIELDS = (
+    "question_id",
+    "assessment",
+    "primary_failure",
+    "baseline_sql_hash",
+    "candidate_sql_hash",
+    "baseline_result_digest",
+    "candidate_result_digest",
+)
+_EVAL_RESULT_FIELDS = frozenset((*_EVAL_STR_FIELDS, "latency_ms"))
+
+
+def _validate_eval_results(eval_results: Optional[Sequence[Any]]) -> list[dict]:
+    """Validate the shape of each ``eval_results[]`` entry against the §7.1 contract.
+
+    Each entry must be an object whose keys are all recognized eval-result fields; string
+    columns must be strings and ``latency_ms`` an integer. Raises
+    :class:`ToolValidationError` on a malformed entry. Returns the cleaned list (``[]`` when
+    no eval rows were supplied).
+    """
+    if eval_results is None:
+        return []
+    if not isinstance(eval_results, (list, tuple)):
+        raise ToolValidationError("`eval_results` must be a list of objects.")
+    cleaned: list[dict] = []
+    for i, entry in enumerate(eval_results):
+        if not isinstance(entry, dict):
+            raise ToolValidationError(
+                f"eval_results[{i}] must be an object (got {type(entry).__name__})."
+            )
+        unknown = set(entry) - _EVAL_RESULT_FIELDS
+        if unknown:
+            allowed = ", ".join(sorted(_EVAL_RESULT_FIELDS))
+            raise ToolValidationError(
+                f"eval_results[{i}] has unknown field(s): {', '.join(sorted(unknown))}; "
+                f"allowed fields: {allowed}"
+            )
+        latency = entry.get("latency_ms")
+        # bool is an int subclass — reject it explicitly so True/False can't pass as latency.
+        if latency is not None and (isinstance(latency, bool) or not isinstance(latency, int)):
+            raise ToolValidationError(f"eval_results[{i}].latency_ms must be an integer.")
+        for key in _EVAL_STR_FIELDS:
+            value = entry.get(key)
+            if value is not None and not isinstance(value, str):
+                raise ToolValidationError(f"eval_results[{i}].{key} must be a string.")
+        cleaned.append(dict(entry))
+    return cleaned
 
 
 # ---------------------------------------------------------------------------
@@ -126,6 +178,56 @@ def save_report_core(
         config_version_id=config_version_id,
         skill_name=skill_name,
         redacted=redacted,
+        idempotency_key=idempotency_key,
+    )
+    result["ok"] = True
+    return result
+
+
+def record_optimization_run_core(
+    store: UCTableStore,
+    *,
+    space_id: str,
+    run_id: str,
+    eval_results: Optional[Sequence[Any]] = None,
+    baseline_score: Optional[float] = None,
+    candidate_score: Optional[float] = None,
+    score_delta: Optional[float] = None,
+    fixed_count: Optional[int] = None,
+    regressed_count: Optional[int] = None,
+    unchanged_count: Optional[int] = None,
+    excluded_count: Optional[int] = None,
+    decision: Optional[str] = None,
+    parent_config_version_id: Optional[str] = None,
+    result_config_version_id: Optional[str] = None,
+    change_summary: Optional[str] = None,
+    idempotency_key: Optional[str] = None,
+) -> dict:
+    _require(space_id, "space_id")
+    _require(run_id, "run_id")
+    cleaned_evals = _validate_eval_results(eval_results)
+
+    # Convenience: derive score_delta when the caller omits it but both endpoints exist,
+    # so the stored row is internally consistent (spec §7.1 score_delta column).
+    effective_delta = score_delta
+    if effective_delta is None and baseline_score is not None and candidate_score is not None:
+        effective_delta = candidate_score - baseline_score
+
+    result = store.record_optimization_run(
+        space_id=space_id,
+        run_id=run_id,
+        eval_results=cleaned_evals,
+        baseline_score=baseline_score,
+        candidate_score=candidate_score,
+        score_delta=effective_delta,
+        fixed_count=fixed_count,
+        regressed_count=regressed_count,
+        unchanged_count=unchanged_count,
+        excluded_count=excluded_count,
+        decision=decision,
+        parent_config_version_id=parent_config_version_id,
+        result_config_version_id=result_config_version_id,
+        change_summary=change_summary,
         idempotency_key=idempotency_key,
     )
     result["ok"] = True
@@ -221,7 +323,7 @@ def _run_tool(settings: Settings, tool_name: str, core: Callable[[UCTableStore],
 
 
 def register_tools(mcp_server, settings: Settings) -> None:
-    """Register the four P1 tools on the FastMCP server."""
+    """Register the P1 write/read tools + the P2 ``record_optimization_run`` on the server."""
 
     @mcp_server.tool
     def save_config_snapshot(
@@ -304,6 +406,56 @@ def register_tools(mcp_server, settings: Settings) -> None:
                 config_version_id=config_version_id,
                 skill_name=skill_name,
                 redacted=effective_redacted,
+                idempotency_key=idempotency_key,
+            ),
+        )
+
+    @mcp_server.tool
+    def record_optimization_run(
+        space_id: str,
+        run_id: str,
+        eval_results: Optional[list[dict]] = None,
+        baseline_score: Optional[float] = None,
+        candidate_score: Optional[float] = None,
+        score_delta: Optional[float] = None,
+        fixed_count: Optional[int] = None,
+        regressed_count: Optional[int] = None,
+        unchanged_count: Optional[int] = None,
+        excluded_count: Optional[int] = None,
+        decision: Optional[str] = None,
+        parent_config_version_id: Optional[str] = None,
+        result_config_version_id: Optional[str] = None,
+        change_summary: Optional[str] = None,
+        idempotency_key: Optional[str] = None,
+    ) -> dict:
+        """Persist a tuning run: one run summary + per-question eval results + decision.
+
+        Writes one row to ``optimization_runs`` and one row per ``eval_results`` entry to
+        ``eval_results`` (FK ``run_id``). The run is keyed by an id derived from
+        ``idempotency_key`` (default: ``run_id``), so a retry returns the existing run with
+        ``deduplicated=true`` and does not re-insert eval rows. ``score_delta`` is derived
+        from ``candidate_score - baseline_score`` when omitted and both are present.
+        Returns ``{run_id, eval_count, deduplicated}``. (Writes optimization_runs + eval_results.)
+        """
+        return _run_tool(
+            settings,
+            "record_optimization_run",
+            lambda store: record_optimization_run_core(
+                store,
+                space_id=space_id,
+                run_id=run_id,
+                eval_results=eval_results,
+                baseline_score=baseline_score,
+                candidate_score=candidate_score,
+                score_delta=score_delta,
+                fixed_count=fixed_count,
+                regressed_count=regressed_count,
+                unchanged_count=unchanged_count,
+                excluded_count=excluded_count,
+                decision=decision,
+                parent_config_version_id=parent_config_version_id,
+                result_config_version_id=result_config_version_id,
+                change_summary=change_summary,
                 idempotency_key=idempotency_key,
             ),
         )

--- a/genie-code/mcp-genie-space-history/app/tests/test_optimization_runs.py
+++ b/genie-code/mcp-genie-space-history/app/tests/test_optimization_runs.py
@@ -1,0 +1,386 @@
+"""record_optimization_run: 1 run row + N eval rows, idempotency, validation, resolution.
+
+One ``optimization_runs`` row plus one ``eval_results`` row per entry are written via
+``_InsertBuilder`` with server-side ``created_at``/``created_by``. The run is keyed by an
+id derived from the idempotency key (default ``run_id``) with read-before-write, so a
+retry never duplicates the run or its eval rows (spec §6/§7.1).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+import pytest
+from fastmcp import FastMCP
+
+from server import schema
+from server import tools as tools_module
+from server.config import Settings
+from server.errors import ToolValidationError
+from server.sql import QueryResult
+from server.store import UCTableStore
+from server.tools import (
+    get_artifact_core,
+    list_history_core,
+    record_optimization_run_core,
+    register_tools,
+)
+
+from .conftest import InMemoryBackend, param_value
+
+_LIST_COLUMNS = ["id", "type", "version", "created_at", "created_by", "summary", "decision"]
+
+# A representative eval batch: mix of fully-populated, minimal, and partial entries.
+EVALS = [
+    {
+        "question_id": "q1",
+        "assessment": "pass",
+        "primary_failure": None,
+        "baseline_sql_hash": "bh1",
+        "candidate_sql_hash": "ch1",
+        "baseline_result_digest": "bd1",
+        "candidate_result_digest": "cd1",
+        "latency_ms": 1200,
+    },
+    {"question_id": "q2", "assessment": "fail", "primary_failure": "wrong_join"},
+    {"question_id": "q3", "assessment": "pass", "latency_ms": 800},
+]
+
+
+def _run_inserts(backend):
+    return backend.inserts_into(schema.OPTIMIZATION_RUNS)
+
+
+def _eval_inserts(backend):
+    return backend.inserts_into(schema.EVAL_RESULTS)
+
+
+# --- happy path -------------------------------------------------------------
+def test_happy_path_one_run_row_and_n_eval_rows(store, backend):
+    result = record_optimization_run_core(
+        store,
+        space_id="s1",
+        run_id="run-123",
+        eval_results=EVALS,
+        baseline_score=0.5,
+        candidate_score=1.0,
+        fixed_count=2,
+        regressed_count=1,
+        unchanged_count=5,
+        excluded_count=0,
+        decision="accepted",
+        parent_config_version_id="cfg-parent",
+        result_config_version_id="cfg-result",
+        change_summary="tightened joins",
+    )
+
+    assert result["ok"] is True
+    assert result["deduplicated"] is False
+    assert result["eval_count"] == 3
+    assert len(result["run_id"]) == 32  # 32-char hex logical id
+
+    # Exactly one run row + one row per eval entry.
+    run_calls = _run_inserts(backend)
+    assert len(run_calls) == 1
+    assert len(_eval_inserts(backend)) == 3
+    assert len(backend.rows[schema.OPTIMIZATION_RUNS]) == 1
+    assert len(backend.rows[schema.EVAL_RESULTS]) == 3
+
+
+def test_run_row_columns_and_params(store, backend):
+    result = record_optimization_run_core(
+        store,
+        space_id="s1",
+        run_id="run-123",
+        eval_results=EVALS,
+        baseline_score=0.5,
+        candidate_score=1.0,
+        fixed_count=2,
+        regressed_count=1,
+        unchanged_count=5,
+        excluded_count=0,
+        decision="accepted",
+        parent_config_version_id="cfg-parent",
+        result_config_version_id="cfg-result",
+        change_summary="tightened joins",
+    )
+    sql, params = _run_inserts(backend)[-1]
+
+    # The stored PK is the derived run id that the tool returns.
+    assert param_value(params, "run_id") == result["run_id"]
+    assert param_value(params, "space_id") == "s1"
+    assert param_value(params, "baseline_score") == "0.5"
+    assert param_value(params, "candidate_score") == "1.0"
+    # score_delta derived from candidate - baseline when omitted.
+    assert param_value(params, "score_delta") == "0.5"
+    assert param_value(params, "fixed_count") == "2"
+    assert param_value(params, "regressed_count") == "1"
+    assert param_value(params, "unchanged_count") == "5"
+    assert param_value(params, "excluded_count") == "0"  # 0 is bound, not dropped
+    assert param_value(params, "decision") == "accepted"
+    assert param_value(params, "parent_config_version_id") == "cfg-parent"
+    assert param_value(params, "result_config_version_id") == "cfg-result"
+    assert param_value(params, "change_summary") == "tightened joins"
+    # created_at/created_by stamped server-side (no bound params).
+    assert "current_timestamp()" in sql
+    assert "current_user()" in sql
+    assert param_value(params, "created_at") is None
+    assert param_value(params, "created_by") is None
+
+
+def test_eval_rows_carry_fk_inherited_space_and_distinct_ids(store, backend):
+    result = record_optimization_run_core(
+        store, space_id="s1", run_id="run-123", eval_results=EVALS
+    )
+    eval_calls = _eval_inserts(backend)
+    assert len(eval_calls) == 3
+
+    eval_run_ids = set()
+    for sql, params in eval_calls:
+        # FK back to the run + the run's space_id inherited onto every eval row.
+        assert param_value(params, "run_id") == result["run_id"]
+        assert param_value(params, "space_id") == "s1"
+        # created_at/created_by stamped server-side on eval rows too.
+        assert "current_timestamp()" in sql
+        assert "current_user()" in sql
+        assert param_value(params, "created_by") is None
+        eval_run_ids.add(param_value(params, "eval_run_id"))
+    assert len(eval_run_ids) == 3  # each eval row gets a distinct stable PK
+
+    # Per-field binding on the fully-populated first entry.
+    _sql0, p0 = eval_calls[0]
+    assert param_value(p0, "question_id") == "q1"
+    assert param_value(p0, "assessment") == "pass"
+    assert param_value(p0, "baseline_sql_hash") == "bh1"
+    assert param_value(p0, "candidate_sql_hash") == "ch1"
+    assert param_value(p0, "baseline_result_digest") == "bd1"
+    assert param_value(p0, "candidate_result_digest") == "cd1"
+    assert param_value(p0, "latency_ms") == "1200"
+
+
+def test_explicit_score_delta_takes_precedence(store, backend):
+    record_optimization_run_core(
+        store,
+        space_id="s1",
+        run_id="run-1",
+        baseline_score=0.5,
+        candidate_score=1.0,
+        score_delta=0.42,
+    )
+    _sql, params = _run_inserts(backend)[-1]
+    assert param_value(params, "score_delta") == "0.42"
+
+
+def test_no_eval_results_is_valid(store, backend):
+    result = record_optimization_run_core(store, space_id="s1", run_id="run-1")
+    assert result["ok"] is True
+    assert result["eval_count"] == 0
+    assert len(_run_inserts(backend)) == 1
+    assert len(_eval_inserts(backend)) == 0
+
+
+# --- idempotency ------------------------------------------------------------
+def test_idempotent_retry_does_not_duplicate(store, backend):
+    evals = [
+        {"question_id": "q1", "assessment": "pass"},
+        {"question_id": "q2", "assessment": "fail"},
+    ]
+    r1 = record_optimization_run_core(
+        store, space_id="s1", run_id="run-x", eval_results=evals, decision="accepted"
+    )
+    r2 = record_optimization_run_core(
+        store, space_id="s1", run_id="run-x", eval_results=evals, decision="accepted"
+    )
+
+    assert r1["deduplicated"] is False
+    assert r2["deduplicated"] is True
+    assert r2["run_id"] == r1["run_id"]
+    assert r2["eval_count"] == 2
+    # The retry inserts neither a second run row nor the eval rows again.
+    assert len(_run_inserts(backend)) == 1
+    assert len(_eval_inserts(backend)) == 2
+
+
+def test_explicit_idempotency_key_dedupes_across_run_ids(store, backend):
+    # Same key, different run_id input => same derived run row (retry semantics).
+    r1 = record_optimization_run_core(
+        store,
+        space_id="s1",
+        run_id="run-a",
+        eval_results=[{"assessment": "pass"}],
+        idempotency_key="batch-7",
+    )
+    r2 = record_optimization_run_core(
+        store,
+        space_id="s1",
+        run_id="run-b",
+        eval_results=[{"assessment": "pass"}],
+        idempotency_key="batch-7",
+    )
+    assert r2["deduplicated"] is True
+    assert r2["run_id"] == r1["run_id"]
+    assert len(_run_inserts(backend)) == 1
+    assert len(_eval_inserts(backend)) == 1
+
+
+def test_distinct_runs_persist_separately(store, backend):
+    r1 = record_optimization_run_core(store, space_id="s1", run_id="run-a")
+    r2 = record_optimization_run_core(store, space_id="s1", run_id="run-b")
+    assert r1["run_id"] != r2["run_id"]
+    assert len(_run_inserts(backend)) == 2
+    assert len(backend.rows[schema.OPTIMIZATION_RUNS]) == 2
+
+
+# --- validation -------------------------------------------------------------
+def test_missing_space_id_rejected(store):
+    with pytest.raises(ToolValidationError):
+        record_optimization_run_core(store, space_id="", run_id="run-1")
+
+
+def test_missing_run_id_rejected(store):
+    with pytest.raises(ToolValidationError):
+        record_optimization_run_core(store, space_id="s1", run_id="")
+
+
+def test_eval_results_must_be_a_list(store):
+    bad: Any = {"assessment": "pass"}  # an object, not a list of objects
+    with pytest.raises(ToolValidationError):
+        record_optimization_run_core(store, space_id="s1", run_id="run-1", eval_results=bad)
+
+
+def test_non_object_eval_entry_rejected(store):
+    with pytest.raises(ToolValidationError):
+        record_optimization_run_core(
+            store, space_id="s1", run_id="run-1", eval_results=["not-an-object"]
+        )
+
+
+def test_unknown_eval_field_rejected(store):
+    with pytest.raises(ToolValidationError):
+        record_optimization_run_core(
+            store,
+            space_id="s1",
+            run_id="run-1",
+            eval_results=[{"assessment": "pass", "bogus_field": 1}],
+        )
+
+
+def test_bad_latency_type_rejected(store):
+    with pytest.raises(ToolValidationError):
+        record_optimization_run_core(
+            store, space_id="s1", run_id="run-1", eval_results=[{"latency_ms": "fast"}]
+        )
+
+
+def test_bool_latency_rejected(store):
+    # bool is an int subclass — must not slip through as a latency value.
+    with pytest.raises(ToolValidationError):
+        record_optimization_run_core(
+            store, space_id="s1", run_id="run-1", eval_results=[{"latency_ms": True}]
+        )
+
+
+def test_bad_string_field_type_rejected(store):
+    with pytest.raises(ToolValidationError):
+        record_optimization_run_core(
+            store, space_id="s1", run_id="run-1", eval_results=[{"assessment": 123}]
+        )
+
+
+def test_validation_error_inserts_nothing(store, backend):
+    with pytest.raises(ToolValidationError):
+        record_optimization_run_core(
+            store, space_id="s1", run_id="run-1", eval_results=[{"bogus_field": 1}]
+        )
+    assert backend.all_inserts() == []
+
+
+# --- list_history / get_artifact resolution ---------------------------------
+def test_get_artifact_resolves_run(store):
+    saved = record_optimization_run_core(
+        store,
+        space_id="s1",
+        run_id="run-x",
+        eval_results=[{"assessment": "pass"}],
+        decision="accepted",
+    )
+    found = get_artifact_core(store, id=saved["run_id"])
+    assert found["ok"] is True
+    assert found["type"] == "optimization_run"
+    assert found["table"] == schema.OPTIMIZATION_RUNS
+    assert found["record"]["run_id"] == saved["run_id"]
+    assert found["record"]["decision"] == "accepted"
+
+
+def test_get_artifact_resolves_eval_row(store, backend):
+    saved = record_optimization_run_core(
+        store,
+        space_id="s1",
+        run_id="run-x",
+        eval_results=[{"question_id": "q1", "assessment": "pass"}],
+    )
+    _sql, params = _eval_inserts(backend)[0]
+    eval_run_id = param_value(params, "eval_run_id")
+    assert eval_run_id is not None
+    found = get_artifact_core(store, id=eval_run_id)
+    assert found["ok"] is True
+    assert found["type"] == "eval_result"
+    assert found["table"] == schema.EVAL_RESULTS
+    assert found["record"]["run_id"] == saved["run_id"]
+    assert found["record"]["question_id"] == "q1"
+
+
+def test_list_history_unions_optimization_runs(store, backend):
+    run_row = ["rid", "optimization_run", None, "2026-01-01", "alice", "tightened", "accepted"]
+    backend.list_result = QueryResult(_LIST_COLUMNS, [run_row])
+    result = list_history_core(store, space_id="s1")
+    assert result["ok"] is True
+    list_sql, _params = backend.calls[-1]
+    # Both run + eval tables participate in the unfiltered UNION.
+    assert schema.OPTIMIZATION_RUNS in list_sql
+    assert schema.EVAL_RESULTS in list_sql
+    assert result["items"][0]["type"] == "optimization_run"
+    assert result["items"][0]["decision"] == "accepted"
+
+
+def test_list_history_filter_restricts_to_optimization_runs(store, backend):
+    backend.list_result = QueryResult(_LIST_COLUMNS, [])
+    list_history_core(store, space_id="s1", artifact_type="optimization_run")
+    list_sql, _params = backend.calls[-1]
+    assert schema.OPTIMIZATION_RUNS in list_sql
+    assert schema.CONFIG_SNAPSHOTS not in list_sql
+    assert schema.EVAL_RESULTS not in list_sql
+
+
+# --- tool layer (register_tools + _run_tool wiring) -------------------------
+def _registered_tool(settings: Settings, name: str) -> Any:
+    mcp = FastMCP(name="test")
+    register_tools(mcp, settings)
+    return asyncio.run(mcp.get_tool(name))
+
+
+def test_tool_schema_exposes_inputs(settings):
+    tool = _registered_tool(settings, "record_optimization_run")
+    props = tool.parameters["properties"]
+    for key in ("space_id", "run_id", "eval_results", "decision", "baseline_score"):
+        assert key in props
+
+
+def test_record_run_via_tool(settings, monkeypatch):
+    backend = InMemoryBackend()
+    store = UCTableStore(backend, settings, user_name="alice@example.com")
+    monkeypatch.setattr(tools_module, "_build_user_store", lambda _s: store)
+
+    tool = _registered_tool(settings, "record_optimization_run")
+    result = tool.fn(
+        space_id="s1",
+        run_id="run-7",
+        eval_results=[{"question_id": "q1", "assessment": "pass"}],
+        decision="accepted",
+    )
+    assert result["ok"] is True
+    assert result["deduplicated"] is False
+    assert result["eval_count"] == 1
+    assert len(backend.inserts_into(schema.OPTIMIZATION_RUNS)) == 1
+    assert len(backend.inserts_into(schema.EVAL_RESULTS)) == 1


### PR DESCRIPTION
## Summary

Implements **P2** of the Genie Space History MCP — the `record_optimization_run` MCP tool (spec §6 tool #3) on top of the existing P1 server core. No schema changes: the `optimization_runs` + `eval_results` tables and their `TABLE_SPECS` entries already shipped in P1.

The tool persists one tuning run + its per-question eval results:
- writes **one** `optimization_runs` row and **N** `eval_results` rows (FK `run_id`), via the existing `_InsertBuilder`;
- stamps `created_at`/`created_by` server-side (`current_timestamp()`/`current_user()`) on every row, matching the row-filter contract;
- is **idempotent**: the run-row id is derived from a client `idempotency_key` (default: `run_id`) with read-before-write — a retry returns the existing run with `deduplicated=true` and does **not** re-insert eval rows;
- derives `score_delta` from `candidate_score - baseline_score` when omitted;
- returns `{run_id, eval_count, deduplicated}`.

Each eval row gets a stable `eval_run_id` (derived from the run id + its position) and inherits the run's `space_id`. `list_history` / `get_artifact` resolve the run (by `run_id`) and eval rows (by `eval_run_id`) — both tables were already in `TABLE_SPECS`.

## Files changed (only these three)
- `app/server/store.py` — `UCTableStore.record_optimization_run(...)` + `_insert_eval_result(...)` helper; updated the `get_artifact` docstring.
- `app/server/tools.py` — `record_optimization_run_core(...)` with input validation (`space_id`/`run_id` required; each `eval_results[]` entry must be an object with known, correctly-typed fields), and the registered `record_optimization_run` MCP tool wrapped in `_run_tool` (OBO identity + structured errors) exactly like the other tools.
- `app/tests/test_optimization_runs.py` — **new**: happy path (1 run + N eval rows, column/param contracts, server-side stamping), idempotent retry (same key → no duplicate run or eval rows), explicit-key dedupe, validation errors (missing `space_id`/`run_id`, non-list / non-object / unknown-field / bad-type eval entries), and `list_history`/`get_artifact` resolution. Uses the existing fake-SqlExec harness read-only (no `conftest.py` changes).

Out of scope (other PRs own them): the rollback round-trip test and the P5 `SKILL.md` docs edits.

## Gates (run from `app/`)
- `pytest` — **80 passed** (23 new in `test_optimization_runs.py`)
- `ruff check` — **All checks passed!**
- `pyright` — **0 errors, 0 warnings**